### PR TITLE
refactor: move tagged template expression from babel-plugin to compiler

### DIFF
--- a/.changeset/six-dancers-allow.md
+++ b/.changeset/six-dancers-allow.md
@@ -1,0 +1,6 @@
+---
+"@kuma-ui/babel-plugin": patch
+"@kuma-ui/compiler": patch
+---
+
+refactor: move tagged template expression from babel-plugin to compiler

--- a/packages/babel-plugin/src/__test__/__snapshots__/css.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/css.test.ts.snap
@@ -7,7 +7,7 @@ exports[`css function > Snapshot tests > basic usage should match snapshot 1`] =
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { css } from '@kuma-ui/core';
-const style = \\"\\\\uD83D\\\\uDC3B-136547911\\";
+const style = \\"🐻-136547911\\";
 "
 `;
 
@@ -18,7 +18,7 @@ exports[`css function > Snapshot tests > using pseudo props should match snapsho
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { css } from '@kuma-ui/core';
-const style = \\"\\\\uD83D\\\\uDC3B-714656561\\";
+const style = \\"🐻-714656561\\";
 "
 `;
 
@@ -29,6 +29,6 @@ exports[`css function > Snapshot tests > using space props should match snapshot
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { css } from '@kuma-ui/core';
-const style = \\"\\\\uD83D\\\\uDC3B-620795649\\";
+const style = \\"🐻-620795649\\";
 "
 `;

--- a/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
@@ -2,14 +2,14 @@
 
 exports[`styled function > Snapshot tests (runtime: automatic) > basic usage should match snapshot 1`] = `
 "
-.🐻-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-686274543{flex-direction:column;}}
+.🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { styled } from '@kuma-ui/core';
 const Box = props => {
   const existingClassName = props.className || \\"\\";
-  const newClassName = \\"🐻-686274543\\";
+  const newClassName = \\"🐻-101236145\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
   return <__Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
 };
@@ -21,14 +21,14 @@ function App() {
 
 exports[`styled function > Snapshot tests (runtime: automatic) > using className prop should match snapshot 1`] = `
 "
-.🐻-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-686274543{flex-direction:column;}}
+.🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { styled, css } from '@kuma-ui/core';
 const Box = props => {
   const existingClassName = props.className || \\"\\";
-  const newClassName = \\"🐻-686274543\\";
+  const newClassName = \\"🐻-101236145\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
   return <__Box as=\\"span\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
 };
@@ -44,14 +44,14 @@ function App() {
 
 exports[`styled function > Snapshot tests (runtime: automatic) > using pseudo elements should match snapshot 1`] = `
 "
-.🐻-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-686274543{flex-direction:column;}}
+.🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { styled } from '@kuma-ui/core';
 const Box = props => {
   const existingClassName = props.className || \\"\\";
-  const newClassName = \\"🐻-686274543\\";
+  const newClassName = \\"🐻-101236145\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
   return <__Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
 };
@@ -63,14 +63,14 @@ function App() {
 
 exports[`styled function > Snapshot tests (runtime: classic) > basic usage should match snapshot 1`] = `
 "
-.🐻-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-686274543{flex-direction:column;}}
+.🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { styled } from '@kuma-ui/core';
 const Box = props => {
   const existingClassName = props.className || \\"\\";
-  const newClassName = \\"🐻-686274543\\";
+  const newClassName = \\"🐻-101236145\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
   return <__Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
 };
@@ -82,14 +82,14 @@ function App() {
 
 exports[`styled function > Snapshot tests (runtime: classic) > using className prop should match snapshot 1`] = `
 "
-.🐻-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-686274543{flex-direction:column;}}
+.🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { styled, css } from '@kuma-ui/core';
 const Box = props => {
   const existingClassName = props.className || \\"\\";
-  const newClassName = \\"🐻-686274543\\";
+  const newClassName = \\"🐻-101236145\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
   return <__Box as=\\"span\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
 };
@@ -105,14 +105,14 @@ function App() {
 
 exports[`styled function > Snapshot tests (runtime: classic) > using pseudo elements should match snapshot 1`] = `
 "
-.🐻-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-686274543{flex-direction:column;}}
+.🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { styled } from '@kuma-ui/core';
 const Box = props => {
   const existingClassName = props.className || \\"\\";
-  const newClassName = \\"🐻-686274543\\";
+  const newClassName = \\"🐻-101236145\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
   return <__Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
 };
@@ -124,14 +124,14 @@ function App() {
 
 exports[`styled function > Snapshot tests (runtime: undefined) > basic usage should match snapshot 1`] = `
 "
-.🐻-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-686274543{flex-direction:column;}}
+.🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { styled } from '@kuma-ui/core';
 const Box = props => {
   const existingClassName = props.className || \\"\\";
-  const newClassName = \\"🐻-686274543\\";
+  const newClassName = \\"🐻-101236145\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
   return <__Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
 };
@@ -143,14 +143,14 @@ function App() {
 
 exports[`styled function > Snapshot tests (runtime: undefined) > using className prop should match snapshot 1`] = `
 "
-.🐻-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-686274543{flex-direction:column;}}
+.🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { styled, css } from '@kuma-ui/core';
 const Box = props => {
   const existingClassName = props.className || \\"\\";
-  const newClassName = \\"🐻-686274543\\";
+  const newClassName = \\"🐻-101236145\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
   return <__Box as=\\"span\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
 };
@@ -166,14 +166,14 @@ function App() {
 
 exports[`styled function > Snapshot tests (runtime: undefined) > using pseudo elements should match snapshot 1`] = `
 "
-.🐻-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-686274543{flex-direction:column;}}
+.🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { styled } from '@kuma-ui/core';
 const Box = props => {
   const existingClassName = props.className || \\"\\";
-  const newClassName = \\"🐻-686274543\\";
+  const newClassName = \\"🐻-101236145\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
   return <__Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
 };

--- a/packages/babel-plugin/src/processTaggedTemplateExpression.ts
+++ b/packages/babel-plugin/src/processTaggedTemplateExpression.ts
@@ -22,19 +22,6 @@ export const processTaggedTemplateExpression = (
       // Check if the tag is a CallExpression with the callee named 'styled'
       const { node } = path;
 
-      // css``
-      if (
-        t.isIdentifier(node.tag) &&
-        importedStyleFunctions["css"] === node.tag.name
-      ) {
-        const cssString = node.quasi.quasis
-          .map((quasi) => quasi.value.raw)
-          .join("");
-        const className = cssString ? sheet.parseCSS(cssString) : undefined;
-        if (className) path.replaceWith(t.stringLiteral(className));
-        return;
-      }
-
       const hasStyled = Object.keys(importedStyleFunctions).some(
         (key) =>
           t.isCallExpression(node.tag) &&

--- a/packages/babel-plugin/src/processTaggedTemplateExpression.ts
+++ b/packages/babel-plugin/src/processTaggedTemplateExpression.ts
@@ -22,6 +22,19 @@ export const processTaggedTemplateExpression = (
       // Check if the tag is a CallExpression with the callee named 'styled'
       const { node } = path;
 
+      // css``
+      if (
+        t.isIdentifier(node.tag) &&
+        importedStyleFunctions["css"] === node.tag.name
+      ) {
+        const cssString = node.quasi.quasis
+          .map((quasi) => quasi.value.raw)
+          .join("");
+        const className = cssString ? sheet.parseCSS(cssString) : undefined;
+        if (className) path.replaceWith(t.stringLiteral(className));
+        return;
+      }
+
       const hasStyled = Object.keys(importedStyleFunctions).some(
         (key) =>
           t.isCallExpression(node.tag) &&

--- a/packages/babel-plugin/src/visitor.ts
+++ b/packages/babel-plugin/src/visitor.ts
@@ -36,7 +36,7 @@ export const visitor = ({ types: t, template }: Core) => {
         // Process CSS function calls and generate the hashed classNames
         // processCSS(path, t, template, importedStyleFunctions);
         // Process TaggedTemplateExpressions with styled components and generate the hashed classNames
-        processTaggedTemplateExpression(path, template, importedStyleFunctions);
+        // processTaggedTemplateExpression(path, template, importedStyleFunctions);
         // Traversal over the JSX elements in the Program node to identify Kuma-UI components,
         // processComponents(path, importedStyleFunctions);
 

--- a/packages/compiler/src/compile.ts
+++ b/packages/compiler/src/compile.ts
@@ -65,7 +65,7 @@ const compile = (
         }
       }
       // styled("xxx")``
-      if (
+      else if (
         Node.isCallExpression(tag) &&
         tag.getExpressionIfKind(SyntaxKind.Identifier)?.getText() ===
           bindings["styled"]

--- a/packages/compiler/src/compile.ts
+++ b/packages/compiler/src/compile.ts
@@ -52,15 +52,42 @@ const compile = (
       if (result) css.push(result.css);
     }
     if (Node.isTaggedTemplateExpression(node)) {
+      const tag = node.getTag();
       // css``
-      const cssTag = node.getTag();
-      if (cssTag.getText() !== bindings["css"]) return;
-      const cssTemplateLiteral = node.getTemplate();
-      if (Node.isNoSubstitutionTemplateLiteral(cssTemplateLiteral)) {
-        const cssString = cssTemplateLiteral.getLiteralText();
-        const className = cssString ? sheet.parseCSS(cssString) : undefined;
-        if (className) {
-          node.replaceWithText(JSON.stringify(className));
+      if (Node.isIdentifier(tag) && tag.getText() === bindings["css"]) {
+        const cssTemplateLiteral = node.getTemplate();
+        if (Node.isNoSubstitutionTemplateLiteral(cssTemplateLiteral)) {
+          const cssString = cssTemplateLiteral.getLiteralText();
+          const className = cssString ? sheet.parseCSS(cssString) : undefined;
+          if (className) {
+            node.replaceWithText(JSON.stringify(className));
+          }
+        }
+      }
+      // styled("xxx")``
+      if (
+        Node.isCallExpression(tag) &&
+        tag.getExpressionIfKind(SyntaxKind.Identifier)?.getText() ===
+          bindings["styled"]
+      ) {
+        const cssTemplateLiteral = node.getTemplate();
+        if (Node.isNoSubstitutionTemplateLiteral(cssTemplateLiteral)) {
+          const componentArg = tag.getArguments()[0];
+          const component = Node.isStringLiteral(componentArg)
+            ? componentArg.getLiteralText()
+            : "div";
+          const cssString = cssTemplateLiteral.getLiteralText();
+          const className = cssString ? sheet.parseCSS(cssString) : undefined;
+          if (className) {
+            node.replaceWithText(`props => {
+  const existingClassName = props.className || "";
+  const newClassName = "${className || ""}";
+  const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(" ");
+  return <${
+    bindings["Box"]
+  } as="${component}" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
+}`);
+          }
         }
       }
     }

--- a/packages/compiler/src/compile.ts
+++ b/packages/compiler/src/compile.ts
@@ -8,6 +8,7 @@ import {
 import { collectPropsFromJsx } from "./collector";
 import { extractProps } from "./extractor";
 import { componentList } from "@kuma-ui/core/components/componentList";
+import { sheet } from "@kuma-ui/sheet";
 
 const project = new Project({});
 
@@ -49,6 +50,19 @@ const compile = (
         extractedPropsMap
       );
       if (result) css.push(result.css);
+    }
+    if (Node.isTaggedTemplateExpression(node)) {
+      // css``
+      const cssTag = node.getTag();
+      if (cssTag.getText() !== bindings["css"]) return;
+      const cssTemplateLiteral = node.getTemplate();
+      if (Node.isNoSubstitutionTemplateLiteral(cssTemplateLiteral)) {
+        const cssString = cssTemplateLiteral.getLiteralText();
+        const className = cssString ? sheet.parseCSS(cssString) : undefined;
+        if (className) {
+          node.replaceWithText(JSON.stringify(className));
+        }
+      }
     }
   });
   return { code: source.getFullText(), id, css: css.join(" ") };

--- a/packages/compiler/src/processTaggedTemplateExpression.ts
+++ b/packages/compiler/src/processTaggedTemplateExpression.ts
@@ -1,0 +1,53 @@
+import {
+  Node,
+  SyntaxKind,
+  TaggedTemplateExpression,
+} from "ts-morph";
+import { sheet } from "@kuma-ui/sheet";
+
+const parseCssTemplate = (cssTemplateLiteral: Node) => {
+  if (Node.isNoSubstitutionTemplateLiteral(cssTemplateLiteral)) {
+    const cssString = cssTemplateLiteral.getLiteralText();
+    return cssString ? sheet.parseCSS(cssString) : undefined;
+  }
+  return undefined;
+};
+
+export const processTaggedTemplateExpression = (node: TaggedTemplateExpression, bindings: Record<string, string>) => {
+  const tag = node.getTag();
+  // css``
+  if (Node.isIdentifier(tag) && tag.getText() === bindings["css"]) {
+    const cssTemplateLiteral = node.getTemplate();
+    const className = parseCssTemplate(cssTemplateLiteral);
+    if (className) {
+      node.replaceWithText(JSON.stringify(className));
+    }
+  }
+  // styled("xxx")``
+  else if (
+    Node.isCallExpression(tag) &&
+    tag.getExpressionIfKind(SyntaxKind.Identifier)?.getText() ===
+      bindings["styled"]
+  ) {
+    const cssTemplateLiteral = node.getTemplate();
+    const className = parseCssTemplate(cssTemplateLiteral);
+    if (className) {
+      const componentArg = tag.getArguments()[0];
+      const component = Node.isStringLiteral(componentArg)
+        ? componentArg.getLiteralText()
+        : "div";
+      node.replaceWithText(`props => {
+  const existingClassName = props.className || "";
+  const newClassName = "${className || ""}";
+  const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(" ");
+  return <${
+    bindings["Box"]
+  } as="${component}" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
+}`);
+    }
+  }
+};
+
+
+
+

--- a/packages/compiler/src/processTaggedTemplateExpression.ts
+++ b/packages/compiler/src/processTaggedTemplateExpression.ts
@@ -1,8 +1,4 @@
-import {
-  Node,
-  SyntaxKind,
-  TaggedTemplateExpression,
-} from "ts-morph";
+import { Node, SyntaxKind, TaggedTemplateExpression } from "ts-morph";
 import { sheet } from "@kuma-ui/sheet";
 
 const parseCssTemplate = (cssTemplateLiteral: Node) => {
@@ -13,7 +9,10 @@ const parseCssTemplate = (cssTemplateLiteral: Node) => {
   return undefined;
 };
 
-export const processTaggedTemplateExpression = (node: TaggedTemplateExpression, bindings: Record<string, string>) => {
+export const processTaggedTemplateExpression = (
+  node: TaggedTemplateExpression,
+  bindings: Record<string, string>
+) => {
   const tag = node.getTag();
   // css``
   if (Node.isIdentifier(tag) && tag.getText() === bindings["css"]) {
@@ -47,7 +46,3 @@ export const processTaggedTemplateExpression = (node: TaggedTemplateExpression, 
     }
   }
 };
-
-
-
-

--- a/packages/compiler/src/processTaggedTemplateExpression.ts
+++ b/packages/compiler/src/processTaggedTemplateExpression.ts
@@ -1,9 +1,14 @@
-import { Node, SyntaxKind, TaggedTemplateExpression } from "ts-morph";
+import {
+  Node,
+  SyntaxKind,
+  TaggedTemplateExpression,
+  TemplateLiteral,
+} from "ts-morph";
 import { sheet } from "@kuma-ui/sheet";
 
-const parseCssTemplate = (cssTemplateLiteral: Node) => {
-  if (Node.isNoSubstitutionTemplateLiteral(cssTemplateLiteral)) {
-    const cssString = cssTemplateLiteral.getLiteralText();
+const extractClassName = (templateLiteral: TemplateLiteral) => {
+  if (Node.isNoSubstitutionTemplateLiteral(templateLiteral)) {
+    const cssString = templateLiteral.getLiteralText();
     return cssString ? sheet.parseCSS(cssString) : undefined;
   }
   return undefined;
@@ -16,8 +21,7 @@ export const processTaggedTemplateExpression = (
   const tag = node.getTag();
   // css``
   if (Node.isIdentifier(tag) && tag.getText() === bindings["css"]) {
-    const cssTemplateLiteral = node.getTemplate();
-    const className = parseCssTemplate(cssTemplateLiteral);
+    const className = extractClassName(node.getTemplate());
     if (className) {
       node.replaceWithText(JSON.stringify(className));
     }
@@ -28,8 +32,7 @@ export const processTaggedTemplateExpression = (
     tag.getExpressionIfKind(SyntaxKind.Identifier)?.getText() ===
       bindings["styled"]
   ) {
-    const cssTemplateLiteral = node.getTemplate();
-    const className = parseCssTemplate(cssTemplateLiteral);
+    const className = extractClassName(node.getTemplate());
     if (className) {
       const componentArg = tag.getArguments()[0];
       const component = Node.isStringLiteral(componentArg)


### PR DESCRIPTION
We have decided to migrate the static extraction logic of TaggedTemplateExpression from babel-plugin to the compiler.
This means that the elements like styled and css API, which were previously statically extracted using babel, will now be extracted using ts-morph. As a result, we will be able to perform static extraction using ts-evaluate in the future, enabling smarter code processing.
This PR can be seen as a preparation to support interpolations and keyframes.