### PR TITLE
(chore) Update repository references after the organization transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/poteboy/kuma-ui/main/media/logo.webp" alt="Kuma UI logo" width="300" />
+  <img src="https://raw.githubusercontent.com/kuma-ui/kuma-ui/main/media/logo.webp" alt="Kuma UI logo" width="300" />
 </div>
 
 <h1 align='center'>Ultra Fast, Zero Runtime, Headless UI Components</h1>
@@ -18,7 +18,7 @@
 </div>
 
 
-https://github.com/poteboy/kuma-ui/assets/59927325/c3f7da97-dbff-49bb-a578-1cb9134b8dd2
+https://github.com/kuma-ui/kuma-ui/assets/59927325/c3f7da97-dbff-49bb-a578-1cb9134b8dd2
 
 
 ## 🐻‍❄️ Features

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/poteboy/kuma-ui.git"
+    "url": "git+https://github.com/kuam-ui/kuma-ui.git"
   },
   "homepage": "https://www.kuma-ui.com",
   "private": true,

--- a/packages/babel-plugin/README.md
+++ b/packages/babel-plugin/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/poteboy/kuma-ui/main/media/logo.webp" alt="Kuma UI logo" width="300" />
+  <img src="https://raw.githubusercontent.com/kuma-ui/kuma-ui/main/media/logo.webp" alt="Kuma UI logo" width="300" />
 </div>
 
 <h1 align='center'>Ultra Fast, Zero Runtime, Headless UI Components</h1>

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -4,7 +4,7 @@
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/poteboy/kuma-ui.git"
+    "url": "git+https://github.com/kuma-ui/kuma-ui.git"
   },
   "keywords": [
     "react",

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/poteboy/kuma-ui/main/media/logo.webp" alt="Kuma UI logo" width="300" />
+  <img src="https://raw.githubusercontent.com/kuma-ui/kuma-ui/main/media/logo.webp" alt="Kuma UI logo" width="300" />
 </div>
 
 <h1 align='center'>Ultra Fast, Zero Runtime, Headless UI Components</h1>

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -4,7 +4,7 @@
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/poteboy/kuma-ui.git"
+    "url": "git+https://github.com/kuma-ui/kuma-ui.git"
   },
   "keywords": [
     "react",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/poteboy/kuma-ui/main/media/logo.webp" alt="Kuma UI logo" width="300" />
+  <img src="https://raw.githubusercontent.com/kuma-ui/kuma-ui/main/media/logo.webp" alt="Kuma UI logo" width="300" />
 </div>
 
 <h1 align='center'>Ultra Fast, Zero Runtime, Headless UI Components</h1>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/poteboy/kuma-ui.git"
+    "url": "git+https://github.com/kuma-ui/kuma-ui.git"
   },
   "keywords": [
     "react",

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/poteboy/kuma-ui/main/media/logo.webp" alt="Kuma UI logo" width="300" />
+  <img src="https://raw.githubusercontent.com/kuma-ui/kuma-ui/main/media/logo.webp" alt="Kuma UI logo" width="300" />
 </div>
 
 <h1 align='center'>Ultra Fast, Zero Runtime, Headless UI Components</h1>

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -4,7 +4,7 @@
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/poteboy/kuma-ui.git"
+    "url": "git+https://github.com/kuma-ui/kuma-ui.git"
   },
   "keywords": [
     "react",

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/poteboy/kuma-ui/main/media/logo.webp" alt="Kuma UI logo" width="300" />
+  <img src="https://raw.githubusercontent.com/kuma-ui/kuma-ui/main/media/logo.webp" alt="Kuma UI logo" width="300" />
 </div>
 
 <h1 align='center'>Ultra Fast, Zero Runtime, Headless UI Components</h1>

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -4,7 +4,7 @@
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/poteboy/kuma-ui.git"
+    "url": "git+https://github.com/kuma-ui/kuma-ui.git"
   },
   "keywords": [
     "react",

--- a/website/src/components/example/Image.tsx
+++ b/website/src/components/example/Image.tsx
@@ -3,7 +3,7 @@ import { Image } from "@kuma-ui/core";
 export const ImageExample = () => {
   return (
     <Image
-      src="https://raw.githubusercontent.com/poteboy/kuma-ui/main/media/logo.webp"
+      src="https://raw.githubusercontent.com/kuma-ui/kuma-ui/main/media/logo.webp"
       alt="Description of image"
     />
   );

--- a/website/src/pages/docs/Components/Image.mdx
+++ b/website/src/pages/docs/Components/Image.mdx
@@ -24,7 +24,7 @@ import { Image } from "@kuma-ui/core";
 const ImageExample = () => {
   return (
     <Image
-      src="https://raw.githubusercontent.com/poteboy/kuma-ui/main/media/logo.webp"
+      src="https://raw.githubusercontent.com/kuma-ui/kuma-ui/main/media/logo.webp"
       alt="Description of image"
     />
   );

--- a/website/theme.config.jsx
+++ b/website/theme.config.jsx
@@ -134,15 +134,15 @@ export default {
   },
   banner: {
     key: "2.0.0-release",
-    text: <a href="https://github.com/poteboy/kuma-ui">⭐ Leave 🐻‍❄️ a star →</a>,
+    text: <a href="https://github.com/kuma-ui/kuma-ui">⭐ Leave 🐻‍❄️ a star →</a>,
   },
   project: {
-    link: "https://github.com/poteboy/kuma-ui",
+    link: "https://github.com/kuma-ui/kuma-ui",
   },
   chat: {
     link: "https://discord.gg/QrsQ4EPp7G",
   },
-  docsRepositoryBase: "https://github.com/poteboy/kuma-ui/tree/main/website/",
+  docsRepositoryBase: "https://github.com/kuma-ui/kuma-ui/tree/main/website/",
   navbar: {
     extraContent: (
       <>


### PR DESCRIPTION
## Overview
After the repo's organization transition the other day, I noticed there were some additional places where the old owner's name still appears.
Although URLs still work correctly for now by redirecting, it should be fixed, as soon as possible.

This PR fix them.