### PR TITLE
Resolve base style override issue

### DIFF
--- a/example/vite/kuma.config.ts
+++ b/example/vite/kuma.config.ts
@@ -24,6 +24,16 @@ const theme = createTheme({
         gap: "12px",
       },
     },
+    Text: {
+      baseStyle: {
+        color: "red",
+      },
+      variants: {
+        primary: {
+          color: "green",
+        },
+      },
+    },
   },
 });
 

--- a/example/vite/src/App.tsx
+++ b/example/vite/src/App.tsx
@@ -1,10 +1,11 @@
-import { Box, HStack, styled, css, Select as S } from "@kuma-ui/core";
+import { Box, HStack, styled, css, Select as S, Text } from "@kuma-ui/core";
 import { Dynamic } from "./Dynamic";
 
 function App() {
   const red = "red";
   return (
     <HStack flexDir={["row", "column"]}>
+      <Text variant={"primary"}>hello</Text>
       <Dynamic key={1} />
       <Dynamic key={2} />
     </HStack>

--- a/packages/compiler/src/extractor/extract.ts
+++ b/packages/compiler/src/extractor/extract.ts
@@ -34,14 +34,16 @@ export const extractProps = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
   const componentProps: { [key: string]: any } = {};
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- FIXME
+  const variant = theme.getVariants(componentName);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
-  const componentVariantProps: { [key: string]: any } = {};
+  const componentVariantProps: { [key: string]: any } = {
+    ...(variant?.baseStyle as Record<string, string>),
+  };
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call -- FIXME
   const defaultProps = componentDefaultProps(componentName);
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- FIXME
-  const variant = theme.getVariants(componentName);
   let isDefault = false;
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- FIXME
@@ -53,13 +55,12 @@ export const extractProps = (
       styledProps[propName.trim()] = propValue;
     } else if (isPseudoProps(propName.trim())) {
       pseudoProps[propName.trim()] = propValue;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- FIXME
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- FIXME
     } else if (isComponentProps(componentName)(propName.trim())) {
       componentProps[propName.trim()] = propValue;
     } else if (propName.trim() === "variant") {
       Object.assign(
         componentVariantProps,
-        variant?.baseStyle,
         variant?.variants?.[propValue as string]
       );
       jsx.getAttribute("variant")?.remove();
@@ -67,8 +68,6 @@ export const extractProps = (
       isDefault = true;
     }
   }
-
-  Object.assign(componentVariantProps, variant?.baseStyle);
 
   if (
     !(


### PR DESCRIPTION
This PR resolves an issue where variant styles were not overriding base styles as expected. 

For instance, consider the following theme configuration:

```ts:kuma.config.ts
const theme = createTheme({
  components: {
    Text: {
      baseStyle: {
        color: "red",
      },
      variants: {
        primary: {
          color: "green",
        },
      },
    },
  },
});
```

In this scenario, we'd expect `<Text variant={"primary"}>hello</Text>` to render green text, as the primary variant should override the baseStyle. However, the actual behavior was that the text color remained red.

Changes in this PR correct this issue, ensuring that variant styles properly override base styles.