### PR TITLE
fix(website): fix text color of example components from system theme

### DIFF
--- a/website/src/components/example/Heading.tsx
+++ b/website/src/components/example/Heading.tsx
@@ -2,11 +2,11 @@ import { Heading } from "@kuma-ui/core";
 import { useTheme } from "nextra-theme-docs";
 
 export const HeadingExample = () => {
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
   return (
     <Heading
       as="h2"
-      color={theme === "dark" ? "white" : "black"}
+      color={resolvedTheme === "dark" ? "white" : "black"}
       fontSize="24px"
     >
       Hello world

--- a/website/src/components/example/Text.tsx
+++ b/website/src/components/example/Text.tsx
@@ -2,9 +2,9 @@ import { Text } from "@kuma-ui/core";
 import { useTheme } from "nextra-theme-docs";
 
 export const TextExample = () => {
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
   return (
-    <Text color={theme === "dark" ? "white" : "black"} fontSize="16px">
+    <Text color={resolvedTheme === "dark" ? "white" : "black"} fontSize="16px">
       Hello world
     </Text>
   );


### PR DESCRIPTION
Hello maintainers! This is my first Pull Request, so I would appreciate help if there are any mistakes 😃 

## Description

Fixed an issue where the colors of the Text and Heading component of the website did not change correctly when the theme is set to System.

## Background

When I was reading the documentation to try out the Kuma UI, I noticed that the Text component assimilates the background color. Here is a screenshot:

<img width="868" alt="スクリーンショット 2023-08-04 17 37 36" src="https://github.com/kuma-ui/kuma-ui/assets/31152321/537f2f20-f340-4c43-8c17-83c06c40e191">

ref: https://www.kuma-ui.com/docs/Components/Text

This does not happen if the theme is `dark`, but only if the theme is `system` .

## Solution

To get the current theme including system in useTheme, it seems to be better to use `resolvedTheme` .
https://github.com/pacocoursey/next-themes#usetheme-1

In addition, the Heading component, which was searched in the project by useTheme and existed as another use point, has also been fixed.

## How was it tested

I could not find the test code, but I confirmed that it is working in preview.

