### PR TITLE
Fix Logo Transparency Issue in Dark Theme

### DIFF
--- a/website/theme.config.jsx
+++ b/website/theme.config.jsx
@@ -18,6 +18,7 @@ export default {
         <mask
           id="mask0_632_5"
           maskUnits="userSpaceOnUse"
+          style={{ maskType: "alpha" }}
           x="0"
           y="0"
           width="77"


### PR DESCRIPTION
In Kuma's documentation, the title logo becomes slightly transparent when in Dark Theme. To address this, I've set the mask-type of the logo SVG to "alpha".

**Before**:
<img width="182" alt="スクリーンショット 2023-08-05 14 35 44" src="https://github.com/kuma-ui/kuma-ui/assets/59927325/6b994f39-945d-4415-ad69-61135c2ab109">

**After**:
<img width="193" alt="スクリーンショット 2023-08-05 14 35 32" src="https://github.com/kuma-ui/kuma-ui/assets/59927325/2786593e-06a2-4211-a05e-6af62fdc54ca">