### PR TITLE
Enable pnpm cache on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,14 +20,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup node ${{ matrix.node_version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node_version }}
 
       - uses: pnpm/action-setup@v2
         with:
           version: 8.5.1
+
+      - name: Setup node ${{ matrix.node_version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node_version }}
 
       - name: install packages
         run: pnpm install
@@ -43,14 +44,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup node v16
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
 
       - uses: pnpm/action-setup@v2
         with:
           version: 8.5.1
+
+      - name: Setup node v16
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
 
       - name: install packages
         run: pnpm install
@@ -66,14 +68,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup node v16
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
 
       - uses: pnpm/action-setup@v2
         with:
           version: 8.5.1
+
+      - name: Setup node v16
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
 
       - name: install packages
         run: pnpm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,10 @@ jobs:
           version: 8.5.1
 
       - name: Setup node ${{ matrix.node_version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
+          cache: pnpm
 
       - name: install packages
         run: pnpm install
@@ -50,9 +51,10 @@ jobs:
           version: 8.5.1
 
       - name: Setup node v16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: pnpm
 
       - name: install packages
         run: pnpm install
@@ -74,9 +76,10 @@ jobs:
           version: 8.5.1
 
       - name: Setup node v16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: pnpm
 
       - name: install packages
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
+          cache: pnpm
 
       - name: install packages
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,14 +13,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup node ${{ matrix.node_version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node_version }}
 
       - uses: pnpm/action-setup@v2
         with:
           version: 8.5.1
+
+      - name: Setup node ${{ matrix.node_version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node_version }}
 
       - name: install packages
         run: pnpm install


### PR DESCRIPTION
Now, installing dependencies spent 10-15sec, becoming one-third!

Not cached: https://github.com/kuma-ui/kuma-ui/actions/runs/5774108606/job/15650715632?pr=269
Cached: https://github.com/kuma-ui/kuma-ui/actions/runs/5774120528/job/15650743609

The doc about pnpm cache on GitHub Actions here: https://pnpm.io/continuous-integration#github-actions