### PR TITLE
 pnpm install in workflows uses composite action

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,5 +1,5 @@
 name: setup-pnpm
-description: "This is a composite GitHub Action that checks out the repo, sets up pnpm, node and installs the project's dependencies."
+description: "This is a composite GitHub Action that sets up pnpm, node and installs the project's dependencies."
 inputs:
   node_version:
     description: "Node.js version"

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,23 @@
+name: setup-pnpm
+description: "This is a composite GitHub Action that checks out the repo, sets up pnpm, node and installs the project's dependencies."
+inputs:
+  node_version:
+    description: "Node.js version"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: pnpm/action-setup@v2
+      with:
+        version: 8.5.1
+
+    - name: Setup node ${{ inputs.node_version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node_version }}
+        cache: pnpm
+
+    - name: install packages
+      run: pnpm install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,24 +22,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - uses: pnpm/action-setup@v2
+      - uses: ./.github/actions/setup-pnpm
         with:
-          version: 8.5.1
-
-      - name: Setup node ${{ matrix.node_version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node_version }}
-          cache: pnpm
-
-      - name: install packages
-        run: pnpm install
+          node_version: ${{ matrix.node_version }}
 
       - name: Run test
         run: pnpm test
 
       - name: Build packages
         run: pnpm build
+
   lint:
     name: lint
     runs-on: ubuntu-latest
@@ -47,24 +39,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - uses: pnpm/action-setup@v2
+      - uses: ./.github/actions/setup-pnpm
         with:
-          version: 8.5.1
-
-      - name: Setup node v16
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: pnpm
-
-      - name: install packages
-        run: pnpm install
+          node_version: 16
 
       - name: Run lint
         run: pnpm lint
 
       - name: Run format
         run: pnpm format
+
   changeset:
     name: check changeset status
     runs-on: ubuntu-latest
@@ -72,18 +56,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - uses: pnpm/action-setup@v2
+      - uses: ./.github/actions/setup-pnpm
         with:
-          version: 8.5.1
-
-      - name: Setup node v16
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: pnpm
-
-      - name: install packages
-        run: pnpm install
+          node_version: 16
 
       - name: Run changeset status
         run: pnpm changeset status --since origin/main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,21 +11,9 @@ jobs:
       matrix:
         node_version: [16]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - uses: pnpm/action-setup@v2
+      - uses: ./.github/actions/setup-project
         with:
-          version: 8.5.1
-
-      - name: Setup node ${{ matrix.node_version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node_version }}
-          cache: pnpm
-
-      - name: install packages
-        run: pnpm install
+          node_version: ${{ matrix.node_version }}
 
       - name: build packages
         run: pnpm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,10 @@ jobs:
       matrix:
         node_version: [16]
     steps:
-      - uses: ./.github/actions/setup-project
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/setup-pnpm
         with:
           node_version: ${{ matrix.node_version }}
 


### PR DESCRIPTION
The current configuration of github actions is running pnpm install on each job.
This can be made common by using composite.

https://docs.github.com/en/actions/creating-actions/creating-a-composite-action