### PR TITLE
Add support for spacing token

### DIFF
--- a/.changeset/afraid-items-sort.md
+++ b/.changeset/afraid-items-sort.md
@@ -1,0 +1,7 @@
+---
+"@kuma-ui/system": minor
+"@kuma-ui/sheet": minor
+"@kuma-ui/core": minor
+---
+
+Add support for spacing theme token

--- a/example/vite/kuma.config.ts
+++ b/example/vite/kuma.config.ts
@@ -8,6 +8,11 @@ const theme = createTheme({
     },
     green: "green",
   },
+  spaces: {
+    sm: "8px",
+    1: "0.25rem",
+    4: "1rem",
+  },
   components: {
     Box: {
       baseStyle: {

--- a/example/vite/kuma.config.ts
+++ b/example/vite/kuma.config.ts
@@ -8,7 +8,7 @@ const theme = createTheme({
     },
     green: "green",
   },
-  spaces: {
+  spacings: {
     sm: "8px",
     1: "0.25rem",
     4: "1rem",

--- a/example/vite/src/App.tsx
+++ b/example/vite/src/App.tsx
@@ -4,7 +4,7 @@ import { Dynamic } from "./Dynamic";
 function App() {
   const red = "red";
   return (
-    <HStack flexDir={["row", "column"]}>
+    <HStack flexDir={["row", "column"]} gap="spaces.4">
       <Text variant={"primary"}>hello</Text>
       <Dynamic key={1} />
       <Dynamic key={2} />

--- a/example/vite/src/App.tsx
+++ b/example/vite/src/App.tsx
@@ -4,7 +4,7 @@ import { Dynamic } from "./Dynamic";
 function App() {
   const red = "red";
   return (
-    <HStack flexDir={["row", "column"]} gap="spaces.4">
+    <HStack flexDir={["row", "column"]} gap="spacings.4">
       <Text variant={"primary"}>hello</Text>
       <Dynamic key={1} />
       <Dynamic key={2} />

--- a/packages/core/src/theme.test.ts
+++ b/packages/core/src/theme.test.ts
@@ -61,11 +61,39 @@ describe("createTheme", () => {
     }>();
   });
 
+  test("should convert space theme object to expected format", () => {
+    const theme = createTheme({
+      spaces: {
+        1: "0.25rem",
+        4: "1rem",
+        sm: "8px",
+      },
+    });
+
+    expect(theme).toEqual({
+      spaces: {
+        "spaces.1": "0.25rem",
+        "spaces.4": "1rem",
+        "spaces.sm": "8px",
+      },
+    });
+
+    expectTypeOf(theme).toEqualTypeOf<{
+      readonly spaces: {
+        "spaces.1": "0.25rem";
+        "spaces.4": "1rem";
+        "spaces.sm": "8px";
+      };
+      components: unknown;
+    }>();
+  });
+
   test("should return an empty theme when no colors are provided", () => {
     const theme = createTheme({});
 
     expect(theme).toEqual({
       colors: undefined,
+      spaces: undefined,
     });
 
     expectTypeOf(theme).toEqualTypeOf<{

--- a/packages/core/src/theme.test.ts
+++ b/packages/core/src/theme.test.ts
@@ -63,7 +63,7 @@ describe("createTheme", () => {
 
   test("should convert space theme object to expected format", () => {
     const theme = createTheme({
-      spaces: {
+      spacings: {
         1: "0.25rem",
         4: "1rem",
         sm: "8px",
@@ -71,18 +71,18 @@ describe("createTheme", () => {
     });
 
     expect(theme).toEqual({
-      spaces: {
-        "spaces.1": "0.25rem",
-        "spaces.4": "1rem",
-        "spaces.sm": "8px",
+      spacings: {
+        "spacings.1": "0.25rem",
+        "spacings.4": "1rem",
+        "spacings.sm": "8px",
       },
     });
 
     expectTypeOf(theme).toEqualTypeOf<{
-      readonly spaces: {
-        "spaces.1": "0.25rem";
-        "spaces.4": "1rem";
-        "spaces.sm": "8px";
+      readonly spacings: {
+        "spacings.1": "0.25rem";
+        "spacings.4": "1rem";
+        "spacings.sm": "8px";
       };
       components: unknown;
     }>();
@@ -93,7 +93,7 @@ describe("createTheme", () => {
 
     expect(theme).toEqual({
       colors: undefined,
-      spaces: undefined,
+      spacings: undefined,
     });
 
     expectTypeOf(theme).toEqualTypeOf<{

--- a/packages/sheet/src/theme.ts
+++ b/packages/sheet/src/theme.ts
@@ -28,6 +28,7 @@ export type Tokens =
   | "fontWeights"
   | "lineHeights"
   | "letterSpacings"
+  | "spaces"
   | "breakpoints";
 
 export type UserTheme = {

--- a/packages/sheet/src/theme.ts
+++ b/packages/sheet/src/theme.ts
@@ -28,7 +28,7 @@ export type Tokens =
   | "fontWeights"
   | "lineHeights"
   | "letterSpacings"
-  | "spaces"
+  | "spacings"
   | "breakpoints";
 
 export type UserTheme = {

--- a/packages/system/src/column.ts
+++ b/packages/system/src/column.ts
@@ -25,29 +25,23 @@ export type ColumnProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
     AddProperty<CSSProperties<"columnGap", true>, T["spacings"]>
 >;
 
-const columnMappings: Record<
-  ColumnKeys,
-  string | { property: string; converter: ValueConverter }
-> = {
+const columnMappings: Record<ColumnKeys, string> = {
   columnCount: "column-count",
   columnFill: "column-fill",
-  columnGap: {
-    property: "column-gap",
-    converter: spaceConverter,
-  },
+  columnGap: "column-gap",
   columnRule: "column-rule",
   columnRuleColor: "column-rule-color",
   columnRuleStyle: "column-rule-style",
-  columnRuleWidth: {
-    property: "column-rule-width",
-    converter: toCssUnit,
-  },
+  columnRuleWidth: "column-rule-width",
   columnSpan: "column-span",
-  columnWidth: {
-    property: "column-width",
-    converter: toCssUnit,
-  },
+  columnWidth: "column-width",
   columns: "columns",
+};
+
+const converters: Partial<Record<ColumnKeys, ValueConverter>> = {
+  columnGap: spaceConverter,
+  columnRuleWidth: toCssUnit,
+  columnWidth: toCssUnit,
 };
 
 export const column = (props: ColumnProps): ResponsiveStyle => {
@@ -58,11 +52,10 @@ export const column = (props: ColumnProps): ResponsiveStyle => {
     const cssValue = props[key as ColumnKeys];
     if (cssValue != undefined) {
       const property = columnMappings[key as ColumnKeys];
-      const converter =
-        typeof property !== "string" ? property.converter : undefined;
+      const converter = converters[key as ColumnKeys];
 
       const responsiveStyles = applyResponsiveStyles(
-        typeof property !== "string" ? property.property : property,
+        property,
         cssValue,
         converter
       );

--- a/packages/system/src/column.ts
+++ b/packages/system/src/column.ts
@@ -22,7 +22,7 @@ export type ColumnProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
       "columnCount" | "columnWidth" | "columnRuleWidth" | "columns",
       true
     > &
-    AddProperty<CSSProperties<"columnGap", true>, T["spaces"]>
+    AddProperty<CSSProperties<"columnGap", true>, T["spacings"]>
 >;
 
 const columnMappings: Record<

--- a/packages/system/src/column.ts
+++ b/packages/system/src/column.ts
@@ -9,7 +9,6 @@ import { applyResponsiveStyles } from "./responsive";
 import { toCssUnit } from "./toCSS";
 import { ValueConverter, spaceConverter } from "./valueConverters";
 
-// eslint-disable-next-line @typescript-eslint/ban-types
 export type ColumnProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
   CSSProperties<
     | "columnFill"

--- a/packages/system/src/column.ts
+++ b/packages/system/src/column.ts
@@ -7,7 +7,7 @@ import {
 import { ColumnKeys } from "./keys";
 import { applyResponsiveStyles } from "./responsive";
 import { toCssUnit } from "./toCSS";
-import { spaceConverter } from "./valueConverters";
+import { ValueConverter, spaceConverter } from "./valueConverters";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type ColumnProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
@@ -25,16 +25,28 @@ export type ColumnProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
     AddProperty<CSSProperties<"columnGap", true>, T["spaces"]>
 >;
 
-const columnMappings: Record<ColumnKeys, string> = {
+const columnMappings: Record<
+  ColumnKeys,
+  string | { property: string; converter: ValueConverter }
+> = {
   columnCount: "column-count",
   columnFill: "column-fill",
-  columnGap: "column-gap",
+  columnGap: {
+    property: "column-gap",
+    converter: spaceConverter,
+  },
   columnRule: "column-rule",
   columnRuleColor: "column-rule-color",
   columnRuleStyle: "column-rule-style",
-  columnRuleWidth: "column-rule-width",
+  columnRuleWidth: {
+    property: "column-rule-width",
+    converter: toCssUnit,
+  },
   columnSpan: "column-span",
-  columnWidth: "column-width",
+  columnWidth: {
+    property: "column-width",
+    converter: toCssUnit,
+  },
   columns: "columns",
 };
 
@@ -47,17 +59,10 @@ export const column = (props: ColumnProps): ResponsiveStyle => {
     if (cssValue != undefined) {
       const property = columnMappings[key as ColumnKeys];
       const converter =
-        property === columnMappings.columnGap
-          ? spaceConverter
-          : [
-              columnMappings.columnWidth,
-              columnMappings.columnRuleWidth,
-            ].includes(property)
-          ? spaceConverter
-          : undefined;
+        typeof property !== "string" ? property.converter : undefined;
 
       const responsiveStyles = applyResponsiveStyles(
-        property,
+        typeof property !== "string" ? property.property : property,
         cssValue,
         converter
       );

--- a/packages/system/src/column.ts
+++ b/packages/system/src/column.ts
@@ -1,9 +1,16 @@
-import { CSSProperties, ResponsiveStyle } from "./types";
+import {
+  AddProperty,
+  CSSProperties,
+  ResponsiveStyle,
+  ThemeSystemType,
+} from "./types";
 import { ColumnKeys } from "./keys";
 import { applyResponsiveStyles } from "./responsive";
 import { toCssUnit } from "./toCSS";
+import { spaceConverter } from "./valueConverters";
 
-export type ColumnProps = Partial<
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type ColumnProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
   CSSProperties<
     | "columnFill"
     | "columnRule"
@@ -12,13 +19,10 @@ export type ColumnProps = Partial<
     | "columnSpan"
   > &
     CSSProperties<
-      | "columnCount"
-      | "columnGap"
-      | "columnWidth"
-      | "columnRuleWidth"
-      | "columns",
+      "columnCount" | "columnWidth" | "columnRuleWidth" | "columns",
       true
-    >
+    > &
+    AddProperty<CSSProperties<"columnGap", true>, T["spaces"]>
 >;
 
 const columnMappings: Record<ColumnKeys, string> = {
@@ -42,13 +46,16 @@ export const column = (props: ColumnProps): ResponsiveStyle => {
     const cssValue = props[key as ColumnKeys];
     if (cssValue != undefined) {
       const property = columnMappings[key as ColumnKeys];
-      const converter = [
-        columnMappings.columnGap,
-        columnMappings.columnWidth,
-        columnMappings.columnRuleWidth,
-      ].includes(property)
-        ? toCssUnit
-        : undefined;
+      const converter =
+        property === columnMappings.columnGap
+          ? spaceConverter
+          : [
+              columnMappings.columnWidth,
+              columnMappings.columnRuleWidth,
+            ].includes(property)
+          ? spaceConverter
+          : undefined;
+
       const responsiveStyles = applyResponsiveStyles(
         property,
         cssValue,

--- a/packages/system/src/compose.ts
+++ b/packages/system/src/compose.ts
@@ -24,7 +24,7 @@ export type StyledProps<T extends ThemeSystemType = ThemeSystemType> =
   TypographyProps<T> &
     FontProps<T> &
     ColorProps<T> &
-    SpaceProps &
+    SpaceProps<T> &
     AnimationProps &
     TextProps &
     LayoutProps &

--- a/packages/system/src/compose.ts
+++ b/packages/system/src/compose.ts
@@ -28,16 +28,16 @@ export type StyledProps<T extends ThemeSystemType = ThemeSystemType> =
     AnimationProps &
     TextProps &
     LayoutProps &
-    FlexProps &
+    FlexProps<T> &
     BorderProps &
     OutlineProps &
     PositionProps &
     ShadowProps &
-    GridProps &
+    GridProps<T> &
     ListProps &
     EffectProps &
     MaskProps &
-    ColumnProps &
+    ColumnProps<T> &
     BackgroundProps &
     // eslint-disable-next-line @typescript-eslint/no-duplicate-type-constituents -- FIXME
     EffectProps;

--- a/packages/system/src/flex.ts
+++ b/packages/system/src/flex.ts
@@ -1,9 +1,17 @@
 import { toCssUnit } from "./toCSS";
 import { FlexKeys } from "./keys";
 import { applyResponsiveStyles } from "./responsive";
-import { CSSProperties, CSSValue, ResponsiveStyle } from "./types";
+import {
+  AddProperty,
+  CSSProperties,
+  CSSValue,
+  ResponsiveStyle,
+  ThemeSystemType,
+} from "./types";
+import { spaceConverter } from "./valueConverters";
 
-export type FlexProps = Partial<
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type FlexProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
   {
     /**
      * @see flexDirection
@@ -19,7 +27,7 @@ export type FlexProps = Partial<
     CSSProperties<"flexBasis", true> &
     CSSProperties<"flex" | "flexShrink" | "flexGrow", true> &
     CSSProperties<"justifyItems" | "justifySelf" | "justifyContent"> &
-    CSSProperties<"gap", true>
+    AddProperty<CSSProperties<"gap", true>, T["spaces"]>
 >;
 
 const flexMappings: Record<FlexKeys, string> = {
@@ -49,11 +57,12 @@ export const flex = (props: FlexProps): ResponsiveStyle => {
     const cssValue = props[key as FlexKeys];
     if (cssValue != undefined) {
       const property = flexMappings[key as FlexKeys];
-      const converter = [flexMappings.flexBasis, flexMappings.gap].includes(
-        property
-      )
-        ? toCssUnit
-        : undefined;
+      const converter =
+        property === flexMappings.flexBasis
+          ? toCssUnit
+          : property === flexMappings.gap
+          ? spaceConverter
+          : undefined;
       const responsiveStyles = applyResponsiveStyles(
         property,
         cssValue,

--- a/packages/system/src/flex.ts
+++ b/packages/system/src/flex.ts
@@ -10,7 +10,6 @@ import {
 } from "./types";
 import { ValueConverter, spaceConverter } from "./valueConverters";
 
-// eslint-disable-next-line @typescript-eslint/ban-types
 export type FlexProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
   {
     /**

--- a/packages/system/src/flex.ts
+++ b/packages/system/src/flex.ts
@@ -27,7 +27,7 @@ export type FlexProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
     CSSProperties<"flexBasis", true> &
     CSSProperties<"flex" | "flexShrink" | "flexGrow", true> &
     CSSProperties<"justifyItems" | "justifySelf" | "justifyContent"> &
-    AddProperty<CSSProperties<"gap", true>, T["spaces"]>
+    AddProperty<CSSProperties<"gap", true>, T["spacings"]>
 >;
 
 const flexMappings: Record<FlexKeys, string> = {

--- a/packages/system/src/flex.ts
+++ b/packages/system/src/flex.ts
@@ -8,7 +8,7 @@ import {
   ResponsiveStyle,
   ThemeSystemType,
 } from "./types";
-import { spaceConverter } from "./valueConverters";
+import { ValueConverter, spaceConverter } from "./valueConverters";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type FlexProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
@@ -49,6 +49,11 @@ const flexMappings: Record<FlexKeys, string> = {
   gap: "gap",
 } as const;
 
+const converters: Partial<Record<FlexKeys, ValueConverter>> = {
+  gap: spaceConverter,
+  flexBasis: toCssUnit,
+};
+
 export const flex = (props: FlexProps): ResponsiveStyle => {
   let base = "";
   const media: ResponsiveStyle["media"] = {};
@@ -57,12 +62,7 @@ export const flex = (props: FlexProps): ResponsiveStyle => {
     const cssValue = props[key as FlexKeys];
     if (cssValue != undefined) {
       const property = flexMappings[key as FlexKeys];
-      const converter =
-        property === flexMappings.flexBasis
-          ? toCssUnit
-          : property === flexMappings.gap
-          ? spaceConverter
-          : undefined;
+      const converter = converters[key as FlexKeys];
       const responsiveStyles = applyResponsiveStyles(
         property,
         cssValue,

--- a/packages/system/src/grid.ts
+++ b/packages/system/src/grid.ts
@@ -14,7 +14,7 @@ type GapKeys = (typeof gapKeys)[number];
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type GridProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
   CSSProperties<Exclude<GridKeys, GapKeys>> &
-    AddProperty<CSSProperties<GapKeys, true>, T["spaces"]>
+    AddProperty<CSSProperties<GapKeys, true>, T["spacings"]>
 >;
 
 const gridMappings: Record<GridKeys, string> = {

--- a/packages/system/src/grid.ts
+++ b/packages/system/src/grid.ts
@@ -1,13 +1,21 @@
 import { toCssUnit } from "./toCSS";
 import { GridKeys } from "./keys";
 import { applyResponsiveStyles } from "./responsive";
-import { CSSProperties, ResponsiveStyle } from "./types";
+import {
+  AddProperty,
+  CSSProperties,
+  ResponsiveStyle,
+  ThemeSystemType,
+} from "./types";
+import { spaceConverter } from "./valueConverters";
 
-const unitKeys = ["gridGap", "gridColumnGap", "gridRowGap"] as const;
-type UnitKeys = (typeof unitKeys)[number];
+const gapKeys = ["gridGap", "gridColumnGap", "gridRowGap"] as const;
+type GapKeys = (typeof gapKeys)[number];
 
-export type GridProps = Partial<
-  CSSProperties<Exclude<GridKeys, UnitKeys>> & CSSProperties<UnitKeys, true>
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type GridProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
+  CSSProperties<Exclude<GridKeys, GapKeys>> &
+    AddProperty<CSSProperties<GapKeys, true>, T["spaces"]>
 >;
 
 const gridMappings: Record<GridKeys, string> = {
@@ -39,8 +47,8 @@ export const grid = (props: GridProps): ResponsiveStyle => {
     const cssValue = props[key as GridKeys];
     if (cssValue != undefined) {
       const property = gridMappings[key as GridKeys];
-      const converter = unitKeys.includes(key as UnitKeys)
-        ? toCssUnit
+      const converter = gapKeys.includes(key as GapKeys)
+        ? spaceConverter
         : undefined;
       const responsiveStyles = applyResponsiveStyles(
         property,

--- a/packages/system/src/grid.ts
+++ b/packages/system/src/grid.ts
@@ -1,4 +1,3 @@
-import { toCssUnit } from "./toCSS";
 import { GridKeys } from "./keys";
 import { applyResponsiveStyles } from "./responsive";
 import {

--- a/packages/system/src/grid.ts
+++ b/packages/system/src/grid.ts
@@ -11,7 +11,6 @@ import { spaceConverter } from "./valueConverters";
 const gapKeys = ["gridGap", "gridColumnGap", "gridRowGap"] as const;
 type GapKeys = (typeof gapKeys)[number];
 
-// eslint-disable-next-line @typescript-eslint/ban-types
 export type GridProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
   CSSProperties<Exclude<GridKeys, GapKeys>> &
     AddProperty<CSSProperties<GapKeys, true>, T["spacings"]>

--- a/packages/system/src/space.test.ts
+++ b/packages/system/src/space.test.ts
@@ -1,7 +1,16 @@
 import { space, SpaceProps } from "./space";
-import { describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
+import { theme } from "@kuma-ui/sheet";
 
 describe("space utility function", () => {
+  beforeAll(() => {
+    theme.setUserTheme({
+      spacings: {
+        sm: "1rem",
+      },
+    });
+  });
+
   // Arrange
   const testCases: Array<[SpaceProps, string, string]> = [
     [{ margin: 8 }, "margin: 8px;", ""],
@@ -15,6 +24,7 @@ describe("space utility function", () => {
       "@media (min-width: 576px) { margin-left: 8px; margin-right: 8px; }",
     ],
     [{ m: 0 }, "margin: 0px;", ""],
+    [{ margin: "sm" }, "margin: 1rem;", ""],
   ];
 
   test.each(testCases)(

--- a/packages/system/src/space.ts
+++ b/packages/system/src/space.ts
@@ -11,7 +11,6 @@ import {
 import { theme } from "@kuma-ui/sheet";
 import { spaceConverter } from "./valueConverters";
 
-// eslint-disable-next-line @typescript-eslint/ban-types
 export type SpaceProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
   AddProperty<
     CSSProperties<

--- a/packages/system/src/space.ts
+++ b/packages/system/src/space.ts
@@ -1,103 +1,114 @@
 import { toCssUnit } from "./toCSS";
 import { SpaceKeys } from "./keys";
 import { applyResponsiveStyles } from "./responsive";
-import { CSSProperties, CSSValue, ResponsiveStyle } from "./types";
+import {
+  AddProperty,
+  CSSProperties,
+  CSSValue,
+  ResponsiveStyle,
+  ThemeSystemType,
+} from "./types";
+import { theme } from "@kuma-ui/sheet";
 
-export type SpaceProps = Partial<
-  CSSProperties<
-    | "margin"
-    | "marginTop"
-    | "marginRight"
-    | "marginBottom"
-    | "marginLeft"
-    | "padding"
-    | "paddingTop"
-    | "paddingRight"
-    | "paddingBottom"
-    | "paddingLeft",
-    true
-  > & {
-    /**
-     * @see margin
-     */
-    m: CSSValue<"margin", true>;
-    /**
-     * @see marginTop
-     */
-    mt: CSSValue<"marginTop", true>;
-    /**
-     * @see marginRight
-     */
-    mr: CSSValue<"marginRight", true>;
-    /**
-     * @see marginBottom
-     */
-    mb: CSSValue<"marginBottom", true>;
-    /**
-     * @see marginLeft
-     */
-    ml: CSSValue<"marginLeft", true>;
-    /**
-     * @see marginLeft
-     * @see marginRight
-     */
-    marginX: CSSValue<"marginLeft" | "marginRight", true>;
-    /**
-     * @see marginLeft
-     * @see marginRight
-     */
-    mx: CSSValue<"marginLeft" | "marginRight", true>;
-    /**
-     * @see marginTop
-     * @see marginBottom
-     */
-    marginY: CSSValue<"marginTop" | "marginBottom", true>;
-    /**
-     * @see marginTop
-     * @see marginBottom
-     */
-    my: CSSValue<"marginTop" | "marginBottom", true>;
-    /**
-     * @see padding
-     */
-    p: CSSValue<"padding", true>;
-    /**
-     * @see paddingTop
-     */
-    pt: CSSValue<"paddingTop", true>;
-    /**
-     * @see paddingRight
-     */
-    pr: CSSValue<"paddingRight", true>;
-    /**
-     * @see paddingBottom
-     */
-    pb: CSSValue<"paddingBottom", true>;
-    /**
-     * @see paddingLeft
-     */
-    pl: CSSValue<"paddingLeft", true>;
-    /**
-     * @see paddingLeft
-     * @see paddingRight
-     */
-    paddingX: CSSValue<"paddingLeft" | "paddingRight", true>;
-    /**
-     * @see paddingLeft
-     * @see paddingRight
-     */
-    px: CSSValue<"paddingLeft" | "paddingRight", true>;
-    /**
-     * @see paddingTop
-     * @see paddingBottom
-     */
-    paddingY: CSSValue<"paddingTop" | "paddingBottom", true>;
-    /**
-     * @see paddingTop
-     * @see paddingBottom
-     */
-    py: CSSValue<"paddingTop" | "paddingBottom", true>;
-  }
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type SpaceProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
+  AddProperty<
+    CSSProperties<
+      | "margin"
+      | "marginTop"
+      | "marginRight"
+      | "marginBottom"
+      | "marginLeft"
+      | "padding"
+      | "paddingTop"
+      | "paddingRight"
+      | "paddingBottom"
+      | "paddingLeft",
+      true
+    > & {
+      /**
+       * @see margin
+       */
+      m: CSSValue<"margin", true>;
+      /**
+       * @see marginTop
+       */
+      mt: CSSValue<"marginTop", true>;
+      /**
+       * @see marginRight
+       */
+      mr: CSSValue<"marginRight", true>;
+      /**
+       * @see marginBottom
+       */
+      mb: CSSValue<"marginBottom", true>;
+      /**
+       * @see marginLeft
+       */
+      ml: CSSValue<"marginLeft", true>;
+      /**
+       * @see marginLeft
+       * @see marginRight
+       */
+      marginX: CSSValue<"marginLeft" | "marginRight", true>;
+      /**
+       * @see marginLeft
+       * @see marginRight
+       */
+      mx: CSSValue<"marginLeft" | "marginRight", true>;
+      /**
+       * @see marginTop
+       * @see marginBottom
+       */
+      marginY: CSSValue<"marginTop" | "marginBottom", true>;
+      /**
+       * @see marginTop
+       * @see marginBottom
+       */
+      my: CSSValue<"marginTop" | "marginBottom", true>;
+      /**
+       * @see padding
+       */
+      p: CSSValue<"padding", true>;
+      /**
+       * @see paddingTop
+       */
+      pt: CSSValue<"paddingTop", true>;
+      /**
+       * @see paddingRight
+       */
+      pr: CSSValue<"paddingRight", true>;
+      /**
+       * @see paddingBottom
+       */
+      pb: CSSValue<"paddingBottom", true>;
+      /**
+       * @see paddingLeft
+       */
+      pl: CSSValue<"paddingLeft", true>;
+      /**
+       * @see paddingLeft
+       * @see paddingRight
+       */
+      paddingX: CSSValue<"paddingLeft" | "paddingRight", true>;
+      /**
+       * @see paddingLeft
+       * @see paddingRight
+       */
+      px: CSSValue<"paddingLeft" | "paddingRight", true>;
+      /**
+       * @see paddingTop
+       * @see paddingBottom
+       */
+      paddingY: CSSValue<"paddingTop" | "paddingBottom", true>;
+      /**
+       * @see paddingTop
+       * @see paddingBottom
+       */
+      py: CSSValue<"paddingTop" | "paddingBottom", true>;
+    },
+    T["spaces"]
+  >
 >;
 
 const spaceMappings: Record<SpaceKeys, string> = {
@@ -135,6 +146,12 @@ export const space = (props: SpaceProps): ResponsiveStyle => {
   let baseStyles = "";
   const mediaStyles: { [breakpoint: string]: string } = {};
 
+  const userTheme = theme.getUserTheme();
+  const converter: (value: string | number) => string | number = (v) => {
+    console.log(userTheme);
+    return userTheme.spaces?.[v] || toCssUnit(v);
+  };
+
   for (const key in spaceMappings) {
     const cssValue = props[key as SpaceKeys];
     if (cssValue != undefined) {
@@ -143,7 +160,7 @@ export const space = (props: SpaceProps): ResponsiveStyle => {
         const responsiveStyles = applyResponsiveStyles(
           property,
           cssValue,
-          toCssUnit
+          converter
         );
         baseStyles += responsiveStyles.base;
         for (const [breakpoint, css] of Object.entries(

--- a/packages/system/src/space.ts
+++ b/packages/system/src/space.ts
@@ -9,6 +9,7 @@ import {
   ThemeSystemType,
 } from "./types";
 import { theme } from "@kuma-ui/sheet";
+import { spaceConverter } from "./valueConverters";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type SpaceProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
@@ -146,12 +147,6 @@ export const space = (props: SpaceProps): ResponsiveStyle => {
   let baseStyles = "";
   const mediaStyles: { [breakpoint: string]: string } = {};
 
-  const userTheme = theme.getUserTheme();
-  const converter: (value: string | number) => string | number = (v) => {
-    console.log(userTheme);
-    return userTheme.spaces?.[v] || toCssUnit(v);
-  };
-
   for (const key in spaceMappings) {
     const cssValue = props[key as SpaceKeys];
     if (cssValue != undefined) {
@@ -160,7 +155,7 @@ export const space = (props: SpaceProps): ResponsiveStyle => {
         const responsiveStyles = applyResponsiveStyles(
           property,
           cssValue,
-          converter
+          spaceConverter
         );
         baseStyles += responsiveStyles.base;
         for (const [breakpoint, css] of Object.entries(

--- a/packages/system/src/space.ts
+++ b/packages/system/src/space.ts
@@ -108,7 +108,7 @@ export type SpaceProps<T extends ThemeSystemType = ThemeSystemType> = Partial<
        */
       py: CSSValue<"paddingTop" | "paddingBottom", true>;
     },
-    T["spaces"]
+    T["spacings"]
   >
 >;
 

--- a/packages/system/src/valueConverters.test.ts
+++ b/packages/system/src/valueConverters.test.ts
@@ -1,0 +1,34 @@
+import { theme } from "@kuma-ui/sheet";
+import { beforeAll, describe, expect, test } from "vitest";
+import { spaceConverter } from "./valueConverters";
+
+describe("spaceConverter", () => {
+  beforeAll(() => {
+    theme.setUserTheme({
+      spaces: {
+        sm: "1rem",
+      },
+    });
+  });
+
+  test("should correctly convert theme token value", () => {
+    const converted = spaceConverter("sm");
+
+    // Assert
+    expect(converted).toBe("1rem");
+  });
+
+  test("should correctly convert raw string value", () => {
+    const converted = spaceConverter("1px");
+
+    // Assert
+    expect(converted).toBe("1px");
+  });
+
+  test("should correctly convert raw number value", () => {
+    const converted = spaceConverter(1);
+
+    // Assert
+    expect(converted).toBe("1px");
+  });
+});

--- a/packages/system/src/valueConverters.test.ts
+++ b/packages/system/src/valueConverters.test.ts
@@ -5,7 +5,7 @@ import { spaceConverter } from "./valueConverters";
 describe("spaceConverter", () => {
   beforeAll(() => {
     theme.setUserTheme({
-      spaces: {
+      spacings: {
         sm: "1rem",
       },
     });

--- a/packages/system/src/valueConverters.ts
+++ b/packages/system/src/valueConverters.ts
@@ -5,5 +5,5 @@ export type ValueConverter = (value: string | number) => string | number;
 
 export const spaceConverter: ValueConverter = (v) => {
   const userTheme = theme.getUserTheme();
-  return userTheme.spaces?.[v] || toCssUnit(v);
+  return userTheme.spacings?.[v] || toCssUnit(v);
 };

--- a/packages/system/src/valueConverters.ts
+++ b/packages/system/src/valueConverters.ts
@@ -1,9 +1,9 @@
 import { theme } from "@kuma-ui/sheet";
 import { toCssUnit } from "./toCSS";
 
-type Converter = (value: string | number) => string | number;
+export type ValueConverter = (value: string | number) => string | number;
 
-export const spaceConverter: Converter = (v) => {
+export const spaceConverter: ValueConverter = (v) => {
   const userTheme = theme.getUserTheme();
   return userTheme.spaces?.[v] || toCssUnit(v);
 };

--- a/packages/system/src/valueConverters.ts
+++ b/packages/system/src/valueConverters.ts
@@ -1,0 +1,9 @@
+import { theme } from "@kuma-ui/sheet";
+import { toCssUnit } from "./toCSS";
+
+type Converter = (value: string | number) => string | number;
+
+export const spaceConverter: Converter = (v) => {
+  const userTheme = theme.getUserTheme();
+  return userTheme.spaces?.[v] || toCssUnit(v);
+};

--- a/website/src/pages/docs/Theme/CustomizingTheme.mdx
+++ b/website/src/pages/docs/Theme/CustomizingTheme.mdx
@@ -23,6 +23,10 @@ const theme = createTheme({
     },
     blue: "blue",
   },
+  spaces: {
+    sm: "0.5rem",
+    md: "1rem",
+  },
   breakpoints: {
     sm: "400px",
     md: "700px",
@@ -46,7 +50,7 @@ declare module "@kuma-ui/core" {
 export default theme;
 ```
 
-In the above example, the theme is defined with a set of colors, a breakpoint, as well as base styles for the Button component.
+In the above example, the theme is defined with a set of colors, spaces, a breakpoint, as well as base styles for the Button component.
 
 If you're using TypeScript, you can benefit from type inference when writing props for your application by extending the Kuma UI `Theme` interface with your user-defined theme:
 
@@ -70,7 +74,7 @@ declare module "@kuma-ui/core" {
 
 ### Theme Tokens
 
-As of now, the available theme tokens include `colors`, `fonts`, `fontSizes`, `fontWeights`, `lineHeights`, and `letterSpacings`. More theme tokens like `spacing` are actively being worked on and will be incorporated in the future. Check the [Theme Tokens](/docs/Theme/ThemeTokens) page for a detailed guide on using each token.
+As of now, the available theme tokens include `colors`, `fonts`, `fontSizes`, `fontWeights`, `lineHeights`, `letterSpacings`, and `spaces`. Check the [Theme Tokens](/docs/Theme/ThemeTokens) page for a detailed guide on using each token.
 
 ### Breakpoints
 

--- a/website/src/pages/docs/Theme/ThemeTokens.mdx
+++ b/website/src/pages/docs/Theme/ThemeTokens.mdx
@@ -96,6 +96,20 @@ const theme = createTheme({
 });
 ```
 
+## Spacings
+
+Determine the spacing between objects such as `margin` and `padding`.
+
+```ts filename="kuma.config.ts"
+const theme = createTheme({
+  spacings: {
+    sm: "1em",
+    md: "4em",
+    lg: "8em",
+  },
+});
+```
+
 <Callout type="warning">
   As for other tokens such as `spacing`, we are currently actively working to
   incorporate them into Kuma UI. Stay tuned for updates and ensure to check the

--- a/website/src/pages/docs/Theme/ThemeTokens.mdx
+++ b/website/src/pages/docs/Theme/ThemeTokens.mdx
@@ -111,7 +111,7 @@ const theme = createTheme({
 ```
 
 <Callout type="warning">
-  As for other tokens such as `spacing`, we are currently actively working to
-  incorporate them into Kuma UI. Stay tuned for updates and ensure to check the
-  documentation regularly for new features and improvements.
+  As for other tokens, we are currently actively working to incorporate them
+  into Kuma UI. Stay tuned for updates and ensure to check the documentation
+  regularly for new features and improvements.
 </Callout>


### PR DESCRIPTION
Add `spacings` theme token for properties such as `margin`, `padding`, and more.

Mostly similar to #272 but I've introduced `ValueConverter` to simplify the transforming logic. So I'd like to get review of @taishinaritomi.