### PR TITLE
fix(vite): fix hmr issue in vite v1.0.5 and later

### DIFF
--- a/.changeset/poor-rocks-worry.md
+++ b/.changeset/poor-rocks-worry.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/vite": patch
+---
+
+fix(vite): fix hmr issue in vite v1.0.5 and later

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -78,7 +78,7 @@ export default function kumaUI(): Plugin {
     },
     load(url) {
       if (!url.startsWith(`\0${virtualModuleId}`)) return undefined;
-      const id = url.replace(`\0${virtualModuleId}`, "").split("?")[0];
+      const id = url.slice(`\0${virtualModuleId}`.length + 1).split("?")[0];
       return cssLookup[id];
     },
     resolveId(importeeUrl) {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -5,6 +5,7 @@ import { buildSync } from "esbuild";
 import _eval from "eval";
 import { theme, sheet } from "@kuma-ui/sheet";
 import { readdirSync } from "fs";
+import { generateHash } from "@kuma-ui/sheet";
 
 export default function kumaUI(): Plugin {
   let mode: "build" | "serve";
@@ -71,13 +72,13 @@ export default function kumaUI(): Plugin {
       cssLookup[cssRelativePath] = css;
       sheet.reset();
       return (
-        `import "${virtualModuleId}/${cssRelativePath}";
+        `import "${virtualModuleId}/${cssRelativePath}?v=${generateHash(css)}";
 ` + result.code
       );
     },
     load(url) {
       if (!url.startsWith(`\0${virtualModuleId}`)) return undefined;
-      const id = url.slice(`\0${virtualModuleId}`.length + 1);
+      const id = url.replace(`\0${virtualModuleId}`, "").split("?")[0];
       return cssLookup[id];
     },
     resolveId(importeeUrl) {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -63,22 +63,23 @@ export default function kumaUI(): Plugin {
 
       const result = transform(code, id);
       if (!result?.code) return;
-      const cssFilename = path.normalize(`${id.replace(/\.[jt]sx?$/, "")}.css`);
+      const css = (result.metadata as unknown as { css: string }).css || "";
+      const cssFilename = path.normalize(
+        `${id.replace(/\.[jt]sx?$/, "")}-${generateHash(css)}.css`
+      );
       const cssRelativePath = path
         .relative(process.cwd(), cssFilename)
         .replace(/\\/g, path.posix.sep);
-      // const css = sheet.getCSS();
-      const css = (result.metadata as unknown as { css: string }).css || "";
       cssLookup[cssRelativePath] = css;
       sheet.reset();
       return (
-        `import "${virtualModuleId}/${cssRelativePath}?v=${generateHash(css)}";
+        `import "${virtualModuleId}/${cssRelativePath}";
 ` + result.code
       );
     },
     load(url) {
       if (!url.startsWith(`\0${virtualModuleId}`)) return undefined;
-      const id = url.slice(`\0${virtualModuleId}`.length + 1).split("?")[0];
+      const id = url.slice(`\0${virtualModuleId}`.length + 1);
       return cssLookup[id];
     },
     resolveId(importeeUrl) {


### PR DESCRIPTION
resolve https://github.com/kuma-ui/kuma-ui/issues/273

I have successfully resolved the Hot Module Replacement (HMR) issue that was occurring in Vite versions v1.0.5 and later when using Kuma UI. The issue was related to CSS styles not being applied correctly during HMR.

Changes Made:

- Updated the Vite plugin to ensure proper CSS application during HMR.
- Added a hash to the imported CSS file.

This PR addresses the problem reported in issue https://github.com/kuma-ui/kuma-ui/issues/273, which was caused by changes introduced in PR https://github.com/kuma-ui/kuma-ui/pull/231. The issue was traced back to the way CSS was being handled during HMR.