### PR TITLE
fix: Replace broken generateKey with fast-json-stable-stringify for pseudo props

### DIFF
--- a/.changeset/kind-mice-shake.md
+++ b/.changeset/kind-mice-shake.md
@@ -1,0 +1,6 @@
+---
+"@kuma-ui/compiler": patch
+"@kuma-ui/core": patch
+---
+
+fix: Replace broken generateKey with fast-json-stable-stringify for pseudo props

--- a/packages/compiler/src/extractor/extract.ts
+++ b/packages/compiler/src/extractor/extract.ts
@@ -20,6 +20,7 @@ import {
   componentHandler,
 } from "@kuma-ui/core/components/componentList";
 import { theme } from "@kuma-ui/sheet";
+import { stableStringify } from "../utils/stableStringify";
 
 export const extractProps = (
   componentName: (typeof componentList)[keyof typeof componentList],
@@ -93,8 +94,7 @@ export const extractProps = (
     ...styledProps,
     ...pseudoProps,
   };
-
-  const key = generateKey(combinedProps);
+  const key = stableStringify(combinedProps);
   let generatedStyle = styleCache[key];
   // If the result isn't in the cache, generate it and save it to the cache
   if (!generatedStyle) {
@@ -150,19 +150,6 @@ export const extractProps = (
   return { css };
 };
 
-/**
- * Generates a unique key for props, aiding cache efficiency.
- * Incurs O(n log n) cost due to sorting, but it's acceptable given the
- * expensive nature of StyleGenerator's internals.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
-const generateKey = (props: Record<string, any>) => {
-  return Object.entries(props)
-    .filter(([, value]) => value !== undefined)
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .map(([key, value]) => `${key}:${value}`)
-    .join("|");
-};
 const styleCache: {
   [key: string]: { className: string; css: string } | undefined;
 } = {};

--- a/packages/compiler/src/utils/stableStringify.ts
+++ b/packages/compiler/src/utils/stableStringify.ts
@@ -1,0 +1,80 @@
+// FIXME: The same file exists in "core" package. We should unify them in the future to avoid this duplication.
+
+// This file was copied from https://github.com/epoberezkin/fast-json-stable-stringify/blob/49e230da2c84247b29ad4de02c9395793caefd15/index.js, which has MIT license.
+// Note that it's modified a little bit to adapot it to the coding style in the project (e.g. TypeScript). Also the second argument is removed since we do not use it.
+// The following is the original license text (https://github.com/epoberezkin/fast-json-stable-stringify/blob/49e230da2c84247b29ad4de02c9395793caefd15/LICENSE):
+/**
+This software is released under the MIT license:
+
+Copyright (c) 2017 Evgeny Poberezkin
+Copyright (c) 2013 James Halliday
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE./
+**/
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function stableStringify(data: Record<string, any>): string;
+export function stableStringify(data: undefined): undefined;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function stableStringify(data: any): string | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const seen: any[] = [];
+  return (function stringify(node) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (node && node.toJSON && typeof node.toJSON === "function") {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+      node = node.toJSON();
+    }
+
+    if (node === undefined) return;
+    if (typeof node == "number") return isFinite(node) ? "" + node : "null";
+    if (typeof node !== "object") return JSON.stringify(node);
+
+    let i, out;
+    if (Array.isArray(node)) {
+      out = "[";
+      for (i = 0; i < node.length; i++) {
+        if (i) out += ",";
+        out += stringify(node[i]) || "null";
+      }
+      return out + "]";
+    }
+
+    if (node === null) return "null";
+
+    if (seen.indexOf(node) !== -1) {
+      throw new TypeError("Converting circular structure to JSON");
+    }
+
+    const seenIndex = seen.push(node) - 1;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const keys = Object.keys(node).sort();
+    out = "";
+    for (i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const value = stringify(node[key]);
+
+      if (!value) continue;
+      if (out) out += ",";
+      out += JSON.stringify(key) + ":" + value;
+    }
+    seen.splice(seenIndex, 1);
+    return "{" + out + "}";
+  })(data);
+}

--- a/packages/core/src/components/Box/react/utils.ts
+++ b/packages/core/src/components/Box/react/utils.ts
@@ -1,5 +1,6 @@
 import { isStyledProp, isPseudoProps, StyleGenerator } from "@kuma-ui/system";
 import { BoxProps } from "./types";
+import { stableStringify } from "../../../utils/stableStringify";
 
 function isDynamicProp(key: string) {
   if (isStyledProp(key) || isPseudoProps(key) || key === "variant") {
@@ -41,23 +42,9 @@ const styleCache: {
   [key: string]: { className: string; css: string } | undefined;
 } = {};
 
-/**
- * Generates a unique key for props, aiding cache efficiency.
- * Incurs O(n log n) cost due to sorting, but it's acceptable given the
- * expensive nature of StyleGenerator's internals.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
-function generateKey(props: Record<string, any>) {
-  return Object.entries(props)
-    .filter(([, value]) => value !== undefined)
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .map(([key, value]) => `${key}:${value}`)
-    .join("|");
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
 export function getCachedStyle(dynamicProps: Record<string, any>) {
-  const key = generateKey(dynamicProps);
+  const key = stableStringify(dynamicProps);
   let generatedStyle = styleCache[key];
   // If the result isn't in the cache, generate it and save it to the cache
   if (!generatedStyle) {

--- a/packages/core/src/utils/stableStringify.test.ts
+++ b/packages/core/src/utils/stableStringify.test.ts
@@ -1,0 +1,39 @@
+import { stableStringify } from "./stableStringify";
+
+import { describe, expect, test } from "vitest";
+
+describe("stableStringify", () => {
+  test("should stringify sipmle object", () => {
+    expect(
+      stableStringify({
+        a: 3,
+        b: [4, 5],
+        c: 6,
+        z: null,
+        nested: [{ arr: "hello" }],
+      })
+    ).toEqual('{"a":3,"b":[4,5],"c":6,"nested":[{"arr":"hello"}],"z":null}');
+  });
+
+  test("should generate the same string when keys orders are just different", () => {
+    expect(
+      stableStringify({
+        b: 999,
+        a: 33,
+        nested: {
+          y: "y",
+          x: "x",
+        },
+      })
+    ).toEqual(
+      stableStringify({
+        a: 33,
+        nested: {
+          x: "x",
+          y: "y",
+        },
+        b: 999,
+      })
+    );
+  });
+});

--- a/packages/core/src/utils/stableStringify.ts
+++ b/packages/core/src/utils/stableStringify.ts
@@ -1,0 +1,80 @@
+// FIXME: The same file exists in "compiler" package. We should unify them in the future to avoid this duplication.
+
+// This file was copied from https://github.com/epoberezkin/fast-json-stable-stringify/blob/49e230da2c84247b29ad4de02c9395793caefd15/index.js, which has MIT license.
+// Note that it's modified a little bit to adapot it to the coding style in the project (e.g. TypeScript). Also the second argument is removed since we do not use it.
+// The following is the original license text (https://github.com/epoberezkin/fast-json-stable-stringify/blob/49e230da2c84247b29ad4de02c9395793caefd15/LICENSE):
+/**
+This software is released under the MIT license:
+
+Copyright (c) 2017 Evgeny Poberezkin
+Copyright (c) 2013 James Halliday
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE./
+**/
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function stableStringify(data: Record<string, any>): string;
+export function stableStringify(data: undefined): undefined;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function stableStringify(data: any): string | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const seen: any[] = [];
+  return (function stringify(node) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (node && node.toJSON && typeof node.toJSON === "function") {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+      node = node.toJSON();
+    }
+
+    if (node === undefined) return;
+    if (typeof node == "number") return isFinite(node) ? "" + node : "null";
+    if (typeof node !== "object") return JSON.stringify(node);
+
+    let i, out;
+    if (Array.isArray(node)) {
+      out = "[";
+      for (i = 0; i < node.length; i++) {
+        if (i) out += ",";
+        out += stringify(node[i]) || "null";
+      }
+      return out + "]";
+    }
+
+    if (node === null) return "null";
+
+    if (seen.indexOf(node) !== -1) {
+      throw new TypeError("Converting circular structure to JSON");
+    }
+
+    const seenIndex = seen.push(node) - 1;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const keys = Object.keys(node).sort();
+    out = "";
+    for (i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const value = stringify(node[key]);
+
+      if (!value) continue;
+      if (out) out += ",";
+      out += JSON.stringify(key) + ":" + value;
+    }
+    seen.splice(seenIndex, 1);
+    return "{" + out + "}";
+  })(data);
+}


### PR DESCRIPTION
Closes #246 

## Problem

In short, Kuma UI's pseudo props support is basically broken.

Before this PR,  `generateKey` was generating something like `_hover:[object Object]|p:2`. After this PR, it uses `fast-json-stable-stringify` and it generates `{"_hover":{"color":"red"},"p":2}`, which includes nested values.
This is critical when using pseudo props. Because of this, when using pseudo props, most of the time styling was broken since actual values of pseudo stlying is not taken into account when taking a hash for style caching.

I used the following example to confirm the bug:
```tsx
import { Input } from "@kuma-ui/core";

function Demo() {
  return (
    <>
      <Input m={2} _valid={{ bgColor: 'red' }} />
      <Input m={2} _valid={{ bgColor: 'blue' }} />
    </>
  );
}
```
### Before this PR
<img width="320" alt="before" src="https://github.com/kuma-ui/kuma-ui/assets/2931577/7fd99783-8625-4180-b2fa-869e8fcda54d">

Both input elements are red and "bgColor: blue" is completely ignored



### After this PR
<img width="343" alt="after" src="https://github.com/kuma-ui/kuma-ui/assets/2931577/49c957aa-5663-4c7b-89df-542e5baaa860">

Colors are expected

## Solution

Use `fast-json-stable-stringify` instead of using our own implementation of generateKey.

Note that this logic can be hot execution path when Kuma UI fails to extract static styles.
For example, emotion is tying to optimize [the whole "serialize styles" thing](https://github.com/emotion-js/emotion/blob/f3b268f7c52103979402da919c9c0dd3f9e0e189/packages/serialize/src/index.js#L310-L388) and in my experience of using Emotion in large scale website, this was a heavy bottleneck. We might want to revisit this choice in the future but we should fix a bug first.

## The choice of fast-json-stable-stringify

I ran [this benchmark](https://github.com/epoberezkin/fast-json-stable-stringify#benchmark) in my MacBook:
```
fast-json-stable-stringify x 61,432 ops/sec ±0.20% (101 runs sampled)
json-stable-stringify x 48,248 ops/sec ±0.12% (97 runs sampled)
fast-stable-stringify x 65,665 ops/sec ±0.10% (97 runs sampled)
faster-stable-stringify x 55,941 ops/sec ±1.77% (96 runs sampled)
The fastest is fast-stable-stringify
```

For now I would choose "fast-json-stable-stringify" for since I found it's used in [`@jest/transform`](https://github.com/facebook/jest/blob/0fd5b1c37555f485c56a6ad2d6b010a72204f9f6/packages/jest-transform/src/ScriptTransformer.ts#L14-L14).
Also note that this relies on the fact **Kuma UI never relies on prop ordering even for nested cases**.


