### PR TITLE
Add support for BinaryExpressions in handleJsxExpression

### DIFF
--- a/.changeset/brave-items-remain.md
+++ b/.changeset/brave-items-remain.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/compiler": patch
+---
+
+Add support for BinaryExpressions in handleJsxExpression

--- a/packages/compiler/src/collector/expression.ts
+++ b/packages/compiler/src/collector/expression.ts
@@ -48,7 +48,10 @@ export const handleJsxExpression = (
           typeof leftOperand === "number" &&
           typeof rightOperand === "number"
         ) {
-          // FIXME: opted for native switch due to a type conflict between ts-pattern and SyntaxKind which remains unexplained.
+          /**
+           * ts-pattern doesn't work when the conditions use an enum with numeric values due to the TS limitation
+           * @see https://github.com/gvergnaud/ts-pattern/issues/183
+           **/
           switch (operator) {
             case SyntaxKind.PlusToken:
               return leftOperand + rightOperand;


### PR DESCRIPTION
This PR enhances `handleJsxExpression` to support static analysis of BinaryExpressions within JSX props, allowing for arithmetic operations to be evaluated at compile-time.

**Example:**
Previously, expressions like `<Text fontSize={2 + 5} />` weren't statically extractable. With this update, the above JSX will be recognized and evaluated as having a fontSize of `7`.
