### PR TITLE
chore: modified existing test cases with the introduction of `testing-library/jest-dom`

### DIFF
--- a/.changeset/brown-squids-brake.md
+++ b/.changeset/brown-squids-brake.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/core": patch
+---
+
+chore: modified existing test cases with the introduction of testing-library/jest-dom

--- a/packages/core/src/components/Spacer/spacer.test.tsx
+++ b/packages/core/src/components/Spacer/spacer.test.tsx
@@ -1,6 +1,6 @@
 import { spacerHandler } from "./handler";
 import { describe, it, expect } from "vitest";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Spacer } from "./react";
 import React from "react";
 
@@ -50,12 +50,12 @@ describe("Spacer", () => {
       const props = { size: 10, horizontal: true };
 
       // Act
-      const { container } = render(<Spacer {...props} id="spacer" />);
+      render(<Spacer {...props} data-testid="spacer" />);
 
       // Assert
-      expect(
-        window.getComputedStyle(container.firstElementChild as Element).width
-      ).toBe("10px");
+      expect(screen.getByTestId("spacer")).toHaveStyle({
+        width: "10px",
+      });
     });
   });
 });

--- a/packages/core/src/components/Spacer/spacer.test.tsx
+++ b/packages/core/src/components/Spacer/spacer.test.tsx
@@ -1,13 +1,10 @@
 import { spacerHandler } from "./handler";
-import { describe, it, expect, beforeEach } from "vitest";
-import { render, cleanup } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
 import { Spacer } from "./react";
 import React from "react";
 
 describe("Spacer", () => {
-  beforeEach(() => {
-    cleanup();
-  });
   describe("spacerHandler", () => {
     it("should return an empty object if both horizontal and size props are not defined", () => {
       // Arrange

--- a/packages/core/src/tests/vitest.setup.ts
+++ b/packages/core/src/tests/vitest.setup.ts
@@ -1,6 +1,7 @@
 import type { TestingLibraryMatchers } from "@testing-library/jest-dom/matchers";
 import matchers from "@testing-library/jest-dom/matchers";
-import { expect } from "vitest";
+import { cleanup } from "@testing-library/react";
+import { beforeEach, expect } from "vitest";
 
 declare module "vitest" {
   interface Assertion<T>
@@ -9,3 +10,7 @@ declare module "vitest" {
 }
 
 expect.extend(matchers);
+
+beforeEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
Minor modifications were made to the test cases in accordance with https://github.com/kuma-ui/kuma-ui/pull/278 .


- test(core): Run cleanup() on all test cases beforeEach
- fix(core): Replace `getComputedStyle` with `toHaveStyle` from `testing-library/jest-dom`
