### PR TITLE
test(core): add some component tests

### DIFF
--- a/.changeset/friendly-islands-eat.md
+++ b/.changeset/friendly-islands-eat.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/core": patch
+---
+
+test(core): add some component tests

--- a/packages/core/src/components/Box/react/box.test.tsx
+++ b/packages/core/src/components/Box/react/box.test.tsx
@@ -4,7 +4,18 @@ import { Box } from ".";
 import React from "react";
 
 describe("Box component", () => {
-  it("should render correctly with given static props", () => {
+  it("should render correctly with no props", () => {
+    // Arrange
+    const props = {};
+
+    // Act
+    render(<Box {...props}>This is a box</Box>);
+
+    // Assert
+    expect(screen.getByText("This is a box")).toBeInTheDocument();
+  });
+
+  it("should render correctly with given dynamic props", () => {
     // Arrange
     const props = { p: 8, color: "white" };
 

--- a/packages/core/src/components/Button/button.test.tsx
+++ b/packages/core/src/components/Button/button.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { Button } from "./react";
+
+describe("Button component", () => {
+  it("should render correctly with props", () => {
+    // Arrange
+    const props = { p: 8, color: "white" };
+
+    // Act
+    render(<Button {...props}>Submit</Button>);
+
+    // Assert
+    expect(screen.getByRole("button", { name: "Submit" })).toHaveStyle({
+      padding: "8px",
+      color: "rgb(255, 255, 255)",
+    });
+  });
+});

--- a/packages/core/src/components/Flex/flex.test.tsx
+++ b/packages/core/src/components/Flex/flex.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { Flex, FlexProps } from "./react";
+
+describe("Flex component", () => {
+  it("should renders all the allowed shorthand style props", () => {
+    // Arrange
+    const props: FlexProps = {
+      flexDir: "column",
+      justify: "center",
+      alignItems: "center",
+      alignContent: "center",
+      alignSelf: "center",
+      flex: "1 1 auto",
+      flexFlow: "row wrap",
+      flexWrap: "wrap",
+      flexGrow: 1,
+      flexShrink: 1,
+      flexBasis: "auto",
+      justifyItems: "center",
+      justifySelf: "center",
+      gap: 1,
+    };
+
+    // Act
+    render(<Flex {...props}>Flexbox</Flex>);
+
+    // Assert
+    expect(screen.getByText("Flexbox")).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/components/Grid/grid.test.tsx
+++ b/packages/core/src/components/Grid/grid.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { Grid, GridProps } from "./react";
+
+describe("Grid component", () => {
+  it("should renders all the allowed shorthand style props", () => {
+    // Arrange
+    const props: GridProps = {
+      grid: "auto-flow / auto-flow",
+      gridArea: "auto-flow",
+      gridAutoColumns: "auto-flow",
+      gridAutoFlow: "auto-flow",
+      gridAutoRows: "auto-flow",
+      gridColumn: "auto-flow",
+      gridColumnEnd: "auto-flow",
+      gridColumnStart: "auto-flow",
+      gridRow: "auto-flow",
+      gridRowEnd: "auto-flow",
+      gridRowStart: "auto-flow",
+      gridTemplate: "auto-flow",
+      gridTemplateAreas: "auto-flow",
+      gridTemplateColumns: "auto-flow",
+      gridTemplateRows: "auto-flow",
+      gridGap: "auto-flow",
+      gridColumnGap: "auto-flow",
+      gridRowGap: "auto-flow",
+    };
+
+    // Act
+    render(<Grid {...props}>Grid</Grid>);
+
+    // Assert
+    expect(screen.getByText("Grid")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Added simple tests for some components of the core package.
I'm adding tests with a policy of fulfilling coverage to some extent.

![スクリーンショット 2023-08-16 8 45 50](https://github.com/kuma-ui/kuma-ui/assets/31152321/520b41de-2dff-41d0-8c99-dcbe802a6f13)

If this policy is acceptable, it will be reflected in all other components in the next PR.
