### PR TITLE
deploy real example project to codesandbox

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -2,6 +2,6 @@
   "installCommand": "codesandbox:insall",
   "buildCommand": "codesandbox:build",
   "packages": ["packages/*"],
-  "sandboxes": ["/example/webpack"],
+  "sandboxes": ["/example/vite"],
   "node": "16"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -2,6 +2,6 @@
   "installCommand": "codesandbox:insall",
   "buildCommand": "codesandbox:build",
   "packages": ["packages/*"],
-  "sandboxes": ["/examples/webpack"],
+  "sandboxes": ["/example/webpack"],
   "node": "16"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -2,6 +2,6 @@
   "installCommand": "codesandbox:insall",
   "buildCommand": "codesandbox:build",
   "packages": ["packages/*"],
-  "sandboxes": ["new", "react-typescript-react-ts"],
+  "sandboxes": ["/examples/webpack"],
   "node": "16"
 }

--- a/example/vite/package.json
+++ b/example/vite/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "start": "vite",
     "build": "vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"

--- a/example/vite/package.json
+++ b/example/vite/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "start": "vite",
     "build": "vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"


### PR DESCRIPTION
Deploys [our vite example](https://github.com/kuma-ui/kuma-ui/tree/main/example/vite) from codesandbox CI instead of general react example to ease the effort of checking the behavior.

#### Before

https://github.com/kuma-ui/kuma-ui/pull/274#issuecomment-1676238005

#### After

https://github.com/kuma-ui/kuma-ui/pull/290#issuecomment-1684899949