### PR TITLE
Remove regex lookbehinds to support Safari 16.3 or older

### DIFF
--- a/.changeset/mighty-coats-breathe.md
+++ b/.changeset/mighty-coats-breathe.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/sheet": minor
+---
+
+Remove regex lookbehinds to support Safari <= 16.3

--- a/packages/sheet/src/regex.test.ts
+++ b/packages/sheet/src/regex.test.ts
@@ -44,7 +44,7 @@ describe("regex", () => {
       "should removes whitespace around CSS property values correctly",
       ({ input, expected }) => {
         // Act
-        const result = input.replace(cssPropertyRegex, "");
+        const result = input.replace(cssPropertyRegex, "$1$2");
         // Assert
         expect(result).toStrictEqual(expected);
       }
@@ -74,7 +74,10 @@ describe("regex", () => {
       "should removes whitespace except around CSS property values and after commas",
       ({ input, expected }) => {
         // Act
-        const result = input.replace(removeSpacesExceptInPropertiesRegex, "");
+        const result = input.replace(
+          removeSpacesExceptInPropertiesRegex,
+          "$1$2$3"
+        );
         // Assert
         expect(result).toStrictEqual(expected);
       }

--- a/packages/sheet/src/regex.ts
+++ b/packages/sheet/src/regex.ts
@@ -1,6 +1,6 @@
 // removes white space around property values
-export const cssPropertyRegex = /(?<=:)\s+|\s+(?=;)/g;
+export const cssPropertyRegex = /(:)\s+|\s+(;)/g;
 
 // removes whitespace except around CSS property values and after commas.
 export const removeSpacesExceptInPropertiesRegex =
-  /(?<=:)\s+|\s+(?=;)|(?<=\{)\s+|\s+(?=\})|(?<=,)\s+|\s+(?=,)|\s+(?={)/g;
+  /(:)\s+|\s+(?=;)|(\{)\s+|\s+(?=\})|(,)\s+|\s+(?=,)|\s+(?={)/g;

--- a/packages/sheet/src/sheet.test.ts
+++ b/packages/sheet/src/sheet.test.ts
@@ -31,17 +31,17 @@ describe("Sheet class", () => {
     // Assert
     expect(className.startsWith("🐻-")).toBeTruthy();
     expect(cssString).toContain(
-      `.${className}{${style.base.replace(cssPropertyRegex, "")}}`
+      `.${className}{${style.base.replace(cssPropertyRegex, "$1$2")}}`
     );
     expect(cssString).toContain(
       `@media (min-width:768px){.${className}{${style.responsive[
         "768px"
-      ].replace(cssPropertyRegex, "")}}}`
+      ].replace(cssPropertyRegex, "$1$2")}}}`
     );
     expect(cssString).toContain(
       `.${className}${style.pseudo[0].key}{${style.pseudo[0].base.replace(
         cssPropertyRegex,
-        ""
+        "$1$2"
       )}}`
     );
   });
@@ -79,7 +79,7 @@ describe("Sheet class", () => {
     const cssString = sheet.getCSS();
     // Assert
     expect(cssString).toContain(
-      `.${id}{${style.base}}`.replace(cssPropertyRegex, "")
+      `.${id}{${style.base}}`.replace(cssPropertyRegex, "$1$2")
     );
   });
 });

--- a/packages/sheet/src/sheet.ts
+++ b/packages/sheet/src/sheet.ts
@@ -65,7 +65,7 @@ export class Sheet {
   }
 
   private _addBaseRule(className: string, css: string) {
-    css = css.replace(cssPropertyRegex, "");
+    css = css.replace(cssPropertyRegex, "$1$2");
     this.base.push(`.${className}{${css}}`);
   }
 
@@ -74,11 +74,11 @@ export class Sheet {
     css: string,
     breakpoint: string
   ): void {
-    css = css.replace(cssPropertyRegex, "");
+    css = css.replace(cssPropertyRegex, "$1$2");
     const mediaCss =
       `@media (min-width: ${breakpoint}) { .${className} { ${css} } }`.replace(
         removeSpacesExceptInPropertiesRegex,
-        ""
+        "$1$2$3"
       );
     this.responsive.push(mediaCss);
   }
@@ -87,10 +87,10 @@ export class Sheet {
     className: string,
     pseudo: SystemStyle["pseudo"][number]
   ) {
-    const css = pseudo.base.replace(cssPropertyRegex, "");
+    const css = pseudo.base.replace(cssPropertyRegex, "$1$2");
     const pseudoCss = `.${className}${pseudo.key} { ${css} }`.replace(
       removeSpacesExceptInPropertiesRegex,
-      ""
+      "$1$2$3"
     );
     this.pseudo.push(pseudoCss);
     for (const [breakpoint, _css] of Object.entries(pseudo.responsive)) {


### PR DESCRIPTION
Lookbehind assertion is not supported by Safari 16.3 (Released on Jan 23, 2023) or older. It causes errors: `SyntaxError: Invalid regular expression: invalid group specifier name`.

cf. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion#browser_compatibility

This PR removes all of them.