### PR TITLE
Remove regex lookbehinds to support Safari 16.3 or older 

### DIFF
--- a/.changeset/mighty-coats-breathe.md
+++ b/.changeset/mighty-coats-breathe.md
@@ -2,4 +2,4 @@
 "@kuma-ui/sheet": minor
 ---
 
-Remove regex lookbehinds to support Safari <= 16.3
+Remove regex lookbehinds to support Safari <= 16.3 and some refactoring

--- a/.changeset/mighty-coats-breathe.md
+++ b/.changeset/mighty-coats-breathe.md
@@ -1,5 +1,5 @@
 ---
-"@kuma-ui/sheet": minor
+"@kuma-ui/sheet": patch
 ---
 
 Remove regex lookbehinds to support Safari <= 16.3 and some refactoring

--- a/.changeset/mighty-coats-breathe.md
+++ b/.changeset/mighty-coats-breathe.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/sheet": minor
+---
+
+Remove regex lookbehinds to support Safari <= 16.3

--- a/packages/sheet/src/regex.test.ts
+++ b/packages/sheet/src/regex.test.ts
@@ -44,7 +44,7 @@ describe("regex", () => {
       "should removes whitespace around CSS property values correctly",
       ({ input, expected }) => {
         // Act
-        const result = input.replace(cssPropertyRegex, "");
+        const result = input.replace(cssPropertyRegex, "$1$2");
         // Assert
         expect(result).toStrictEqual(expected);
       }
@@ -74,7 +74,10 @@ describe("regex", () => {
       "should removes whitespace except around CSS property values and after commas",
       ({ input, expected }) => {
         // Act
-        const result = input.replace(removeSpacesExceptInPropertiesRegex, "");
+        const result = input.replace(
+          removeSpacesExceptInPropertiesRegex,
+          "$1$2$3"
+        );
         // Assert
         expect(result).toStrictEqual(expected);
       }

--- a/packages/sheet/src/regex.test.ts
+++ b/packages/sheet/src/regex.test.ts
@@ -1,8 +1,11 @@
-import { cssPropertyRegex, removeSpacesExceptInPropertiesRegex } from "./regex";
+import {
+  removeSpacesAroundCssPropertyValues,
+  removeSpacesExceptInProperties,
+} from "./regex";
 import { describe, expect, test } from "vitest";
 
 describe("regex", () => {
-  describe("cssPropertyRegex", () => {
+  describe("removeSpacesAroundCssPropertyValues", () => {
     // Arrange
     const testCases = [
       { input: "color: red;", expected: "color:red;" },
@@ -44,14 +47,14 @@ describe("regex", () => {
       "should removes whitespace around CSS property values correctly",
       ({ input, expected }) => {
         // Act
-        const result = input.replace(cssPropertyRegex, "$1$2");
+        const result = removeSpacesAroundCssPropertyValues(input);
         // Assert
         expect(result).toStrictEqual(expected);
       }
     );
   });
 
-  describe("removeSpacesExceptInPropertiesRegex", () => {
+  describe("removeSpacesExceptInProperties", () => {
     // Arrange
     const testCases = [
       { input: "padding: 10px 20px;", expected: "padding:10px 20px;" },
@@ -74,10 +77,7 @@ describe("regex", () => {
       "should removes whitespace except around CSS property values and after commas",
       ({ input, expected }) => {
         // Act
-        const result = input.replace(
-          removeSpacesExceptInPropertiesRegex,
-          "$1$2$3"
-        );
+        const result = removeSpacesExceptInProperties(input);
         // Assert
         expect(result).toStrictEqual(expected);
       }

--- a/packages/sheet/src/regex.ts
+++ b/packages/sheet/src/regex.ts
@@ -1,6 +1,6 @@
 // removes white space around property values
-export const cssPropertyRegex = /(?<=:)\s+|\s+(?=;)/g;
+export const cssPropertyRegex = /(:)\s+|\s+(;)/g;
 
 // removes whitespace except around CSS property values and after commas.
 export const removeSpacesExceptInPropertiesRegex =
-  /(?<=:)\s+|\s+(?=;)|(?<=\{)\s+|\s+(?=\})|(?<=,)\s+|\s+(?=,)|\s+(?={)/g;
+  /(:)\s+|\s+(?=;)|(\{)\s+|\s+(?=\})|(,)\s+|\s+(?=,)|\s+(?={)/g;

--- a/packages/sheet/src/regex.ts
+++ b/packages/sheet/src/regex.ts
@@ -1,6 +1,6 @@
 export const removeSpacesAroundCssPropertyValues = (css: string) => {
-  const regex = /(:)\s+|\s+(;)/g;
-  return css.replace(regex, "$1$2");
+  const regex = /(:)\s+|\s+(?=;)/g;
+  return css.replace(regex, "$1");
 };
 
 // removes whitespace except around CSS property values and after commas.

--- a/packages/sheet/src/regex.ts
+++ b/packages/sheet/src/regex.ts
@@ -1,6 +1,10 @@
-// removes white space around property values
-export const cssPropertyRegex = /(:)\s+|\s+(;)/g;
+export const removeSpacesAroundCssPropertyValues = (css: string) => {
+  const regex = /(:)\s+|\s+(;)/g;
+  return css.replace(regex, "$1$2");
+};
 
 // removes whitespace except around CSS property values and after commas.
-export const removeSpacesExceptInPropertiesRegex =
-  /(:)\s+|\s+(?=;)|(\{)\s+|\s+(?=\})|(,)\s+|\s+(?=,)|\s+(?={)/g;
+export const removeSpacesExceptInProperties = (css: string) => {
+  const regex = /(:)\s+|\s+(?=;)|(\{)\s+|\s+(?=\})|(,)\s+|\s+(?=,)|\s+(?={)/g;
+  return css.replace(regex, "$1$2$3");
+};

--- a/packages/sheet/src/sheet.test.ts
+++ b/packages/sheet/src/sheet.test.ts
@@ -68,7 +68,7 @@ describe("Sheet class", () => {
     const className = sheet.parseCSS(style);
     // Assert
     const expectedCSS = `.${className}{display:flex;flex-direction:row;}@media (max-width: 768px){.${className}{flex-direction:column;}}.${className}:after{content:" 🦄";}`;
-    expect(sheet.getCSS()).toContain(expectedCSS);
+    expect(sheet.getCSS()).toEqual(expectedCSS);
   });
 
   test("getCSS() should return the CSS string with unique rules", () => {
@@ -76,9 +76,8 @@ describe("Sheet class", () => {
     const id = sheet.addRule(style);
     // Act
     const cssString = sheet.getCSS();
+    const expectedCSS = `.${id}{color:red;}@media (min-width:768px){.${id}{color:blue;}}@media (min-width:768px){.${id}:hover{color:yellow;}}.${id}:hover{color:green;}`;
     // Assert
-    expect(cssString).toContain(
-      removeSpacesAroundCssPropertyValues(`.${id}{${style.base}}`)
-    );
+    expect(cssString).toEqual(expectedCSS);
   });
 });

--- a/packages/sheet/src/sheet.test.ts
+++ b/packages/sheet/src/sheet.test.ts
@@ -1,6 +1,6 @@
 import { sheet, SystemStyle } from "./sheet";
 import { describe, expect, test, beforeEach } from "vitest";
-import { removeSpacesExceptInPropertiesRegex, cssPropertyRegex } from "./regex";
+import { removeSpacesAroundCssPropertyValues } from "./regex";
 
 describe("Sheet class", () => {
   beforeEach(() => {
@@ -31,18 +31,17 @@ describe("Sheet class", () => {
     // Assert
     expect(className.startsWith("🐻-")).toBeTruthy();
     expect(cssString).toContain(
-      `.${className}{${style.base.replace(cssPropertyRegex, "$1$2")}}`
+      `.${className}{${removeSpacesAroundCssPropertyValues(style.base)}}`
     );
     expect(cssString).toContain(
-      `@media (min-width:768px){.${className}{${style.responsive[
-        "768px"
-      ].replace(cssPropertyRegex, "$1$2")}}}`
+      `@media (min-width:768px){.${className}{${removeSpacesAroundCssPropertyValues(
+        style.responsive["768px"]
+      )}}}`
     );
     expect(cssString).toContain(
-      `.${className}${style.pseudo[0].key}{${style.pseudo[0].base.replace(
-        cssPropertyRegex,
-        "$1$2"
-      )}}`
+      `.${className}${
+        style.pseudo[0].key
+      }{${removeSpacesAroundCssPropertyValues(style.pseudo[0].base)}}`
     );
   });
 
@@ -79,7 +78,7 @@ describe("Sheet class", () => {
     const cssString = sheet.getCSS();
     // Assert
     expect(cssString).toContain(
-      `.${id}{${style.base}}`.replace(cssPropertyRegex, "$1$2")
+      removeSpacesAroundCssPropertyValues(`.${id}{${style.base}}`)
     );
   });
 });

--- a/packages/sheet/src/sheet.test.ts
+++ b/packages/sheet/src/sheet.test.ts
@@ -31,17 +31,17 @@ describe("Sheet class", () => {
     // Assert
     expect(className.startsWith("🐻-")).toBeTruthy();
     expect(cssString).toContain(
-      `.${className}{${style.base.replace(cssPropertyRegex, "")}}`
+      `.${className}{${style.base.replace(cssPropertyRegex, "$1$2")}}`
     );
     expect(cssString).toContain(
       `@media (min-width:768px){.${className}{${style.responsive[
         "768px"
-      ].replace(cssPropertyRegex, "")}}}`
+      ].replace(cssPropertyRegex, "$1$2")}}}`
     );
     expect(cssString).toContain(
       `.${className}${style.pseudo[0].key}{${style.pseudo[0].base.replace(
         cssPropertyRegex,
-        ""
+        "$1$2"
       )}}`
     );
   });
@@ -79,7 +79,7 @@ describe("Sheet class", () => {
     const cssString = sheet.getCSS();
     // Assert
     expect(cssString).toContain(
-      `.${id}{${style.base}}`.replace(cssPropertyRegex, "")
+      `.${id}{${style.base}}`.replace(cssPropertyRegex, "$1$2")
     );
   });
 });

--- a/packages/sheet/src/sheet.ts
+++ b/packages/sheet/src/sheet.ts
@@ -1,6 +1,9 @@
 import { theme } from ".";
 import { generateHash } from "./hash";
-import { cssPropertyRegex, removeSpacesExceptInPropertiesRegex } from "./regex";
+import {
+  removeSpacesAroundCssPropertyValues,
+  removeSpacesExceptInProperties,
+} from "./regex";
 import { compile, serialize, stringify, Element } from "stylis";
 
 // to avoid cyclic dependency, we declare an exact same type declared in @kuma-ui/system
@@ -65,8 +68,8 @@ export class Sheet {
   }
 
   private _addBaseRule(className: string, css: string) {
-    css = css.replace(cssPropertyRegex, "$1$2");
-    this.base.push(`.${className}{${css}}`);
+    const minifiedCss = removeSpacesAroundCssPropertyValues(css);
+    this.base.push(`.${className}{${minifiedCss}}`);
   }
 
   private _addMediaRule(
@@ -74,12 +77,10 @@ export class Sheet {
     css: string,
     breakpoint: string
   ): void {
-    css = css.replace(cssPropertyRegex, "$1$2");
-    const mediaCss =
-      `@media (min-width: ${breakpoint}) { .${className} { ${css} } }`.replace(
-        removeSpacesExceptInPropertiesRegex,
-        "$1$2$3"
-      );
+    const minifiedCss = removeSpacesAroundCssPropertyValues(css);
+    const mediaCss = removeSpacesExceptInProperties(
+      `@media (min-width: ${breakpoint}) { .${className} { ${minifiedCss} } }`
+    );
     this.responsive.push(mediaCss);
   }
 
@@ -87,10 +88,8 @@ export class Sheet {
     className: string,
     pseudo: SystemStyle["pseudo"][number]
   ) {
-    const css = pseudo.base.replace(cssPropertyRegex, "$1$2");
-    const pseudoCss = `.${className}${pseudo.key} { ${css} }`.replace(
-      removeSpacesExceptInPropertiesRegex,
-      "$1$2$3"
+    const pseudoCss = removeSpacesExceptInProperties(
+      `.${className}${pseudo.key} { ${pseudo.base} }`
     );
     this.pseudo.push(pseudoCss);
     for (const [breakpoint, _css] of Object.entries(pseudo.responsive)) {

--- a/packages/sheet/src/sheet.ts
+++ b/packages/sheet/src/sheet.ts
@@ -65,7 +65,7 @@ export class Sheet {
   }
 
   private _addBaseRule(className: string, css: string) {
-    css = css.replace(cssPropertyRegex, "");
+    css = css.replace(cssPropertyRegex, "$1$2");
     this.base.push(`.${className}{${css}}`);
   }
 
@@ -74,11 +74,11 @@ export class Sheet {
     css: string,
     breakpoint: string
   ): void {
-    css = css.replace(cssPropertyRegex, "");
+    css = css.replace(cssPropertyRegex, "$1$2");
     const mediaCss =
       `@media (min-width: ${breakpoint}) { .${className} { ${css} } }`.replace(
         removeSpacesExceptInPropertiesRegex,
-        ""
+        "$1$2$3"
       );
     this.responsive.push(mediaCss);
   }
@@ -87,10 +87,10 @@ export class Sheet {
     className: string,
     pseudo: SystemStyle["pseudo"][number]
   ) {
-    const css = pseudo.base.replace(cssPropertyRegex, "");
+    const css = pseudo.base.replace(cssPropertyRegex, "$1$2");
     const pseudoCss = `.${className}${pseudo.key} { ${css} }`.replace(
       removeSpacesExceptInPropertiesRegex,
-      ""
+      "$1$2$3"
     );
     this.pseudo.push(pseudoCss);
     for (const [breakpoint, _css] of Object.entries(pseudo.responsive)) {

--- a/packages/sheet/src/sheet.ts
+++ b/packages/sheet/src/sheet.ts
@@ -88,8 +88,9 @@ export class Sheet {
     className: string,
     pseudo: SystemStyle["pseudo"][number]
   ) {
+    const css = removeSpacesAroundCssPropertyValues(pseudo.base);
     const pseudoCss = removeSpacesExceptInProperties(
-      `.${className}${pseudo.key} { ${pseudo.base} }`
+      `.${className}${pseudo.key} { ${css} }`
     );
     this.pseudo.push(pseudoCss);
     for (const [breakpoint, _css] of Object.entries(pseudo.responsive)) {


### PR DESCRIPTION
Lookbehind assertion is not supported by Safari 16.3 (Released on Jan 23, 2023) or older. It causes errors: `SyntaxError: Invalid regular expression: invalid group specifier name.`

cf. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion#browser_compatibility

This PR removes all of them.