### PR TITLE
fix dev snapshot workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,4 @@ jobs:
           pnpm changeset publish --tag dev
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # changesets/action creates `.npmrc` that refer NPM_TOKEN instead of NODE_AUTH_TOKEN


### PR DESCRIPTION
Followup #300

It seems that `NPM_TOKEN` is correct instead of `NODE_AUTH_TOKEN`.

Failed run: https://github.com/kuma-ui/kuma-ui/actions/runs/5965772915/job/16183953680