### PR TITLE
create npmrc by setup-node instead of changesets/action

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -17,6 +17,7 @@ runs:
       with:
         node-version: ${{ inputs.node_version }}
         cache: pnpm
+        registry-url: "https://registry.npmjs.org"
 
     - name: install packages
       run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish dev snapshot
         if: steps.changesets.outputs.published != 'true'
@@ -38,4 +39,4 @@ jobs:
           pnpm changeset publish --tag dev
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # changesets/action creates `.npmrc` that refer NPM_TOKEN instead of NODE_AUTH_TOKEN
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This will be the final retry!! :bow:

changesets/action seems to create `.npmrc` only when it publish releases. So instead, create `.npmrc` by setup-node.
