### PR TITLE
Improve autocompletion experience of `baseStyle` and `variants`

### DIFF
--- a/.changeset/bright-books-learn.md
+++ b/.changeset/bright-books-learn.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/core": patch
+---
+
+Improve autocompletion experience of `baseStyle` and `variants`

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -11,14 +11,13 @@ import {
   InputThemeTokens,
 } from "./themeTokens";
 import { componentList } from "./components/componentList";
+import { StyledProps } from "@kuma-ui/system";
 
 export type ThemeInput = InputThemeTokens & {
   components?: {
     [_ in keyof typeof componentList]?: {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
-      baseStyle?: any;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
-      variants?: { [key: string]: any };
+      baseStyle?: StyledProps;
+      variants?: { [key: string]: StyledProps };
     };
   };
 };


### PR DESCRIPTION
Currently we can't get any completion in `baseStyle` and `variants` of `kuma.config.js`.

With this PR, we can get completion of property names and values. Still cannot autocomplete custom token as it causes circular reference but it's better experience than `any` type.