### PR TITLE
Introduce `defaultProps` in component theme

### DIFF
--- a/.changeset/silly-penguins-impress.md
+++ b/.changeset/silly-penguins-impress.md
@@ -4,4 +4,4 @@
 "@kuma-ui/core": minor
 ---
 
-Introduce `defaultProps` in component theme with better typing utility `createComponentTheme`.
+Introduce `defaultProps` in component theme

--- a/.changeset/silly-penguins-impress.md
+++ b/.changeset/silly-penguins-impress.md
@@ -1,0 +1,7 @@
+---
+"@kuma-ui/compiler": minor
+"@kuma-ui/sheet": minor
+"@kuma-ui/core": minor
+---
+
+Introduce `defaultProps` in component theme with better typing utility `createComponentTheme`.

--- a/example/vite/.gitignore
+++ b/example/vite/.gitignore
@@ -23,3 +23,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.inspect

--- a/example/vite/kuma.config.ts
+++ b/example/vite/kuma.config.ts
@@ -1,4 +1,4 @@
-import {  createTheme } from "@kuma-ui/core";
+import { createTheme } from "@kuma-ui/core";
 
 const theme = createTheme({
   colors: {
@@ -43,6 +43,7 @@ const theme = createTheme({
       },
       defaultProps: {
         variant: "primary",
+        textDecoration: "line-through",
       },
     },
   },

--- a/example/vite/kuma.config.ts
+++ b/example/vite/kuma.config.ts
@@ -1,4 +1,4 @@
-import { createTheme } from "@kuma-ui/core";
+import { createComponentTheme, createTheme } from "@kuma-ui/core";
 
 const theme = createTheme({
   colors: {
@@ -29,16 +29,22 @@ const theme = createTheme({
         gap: "12px",
       },
     },
-    Text: {
+    Text: createComponentTheme({
       baseStyle: {
-        color: "red",
+        textDecoration: "underline",
       },
       variants: {
         primary: {
           color: "green",
         },
+        secondary: {
+          color: "blue",
+        },
       },
-    },
+      defaultProps: {
+        variant: "primary",
+      },
+    }),
   },
 });
 

--- a/example/vite/src/App.tsx
+++ b/example/vite/src/App.tsx
@@ -5,7 +5,7 @@ function App() {
   const red = "red";
   return (
     <HStack flexDir={["row", "column"]} gap="spacings.4">
-      <Text variant={"primary"}>hello</Text>
+      <Text>hello</Text>
       <Dynamic key={1} />
       <Dynamic key={2} />
     </HStack>

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "bootstrap": "pnpm install",
     "build": "turbo run build",
+    "build:packages": "turbo run build --filter @kuma-ui/*",
     "test": "turbo run test",
     "lint": "eslint './packages/**/*.{js,ts,jsx,tsx}' --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint --fix './packages/**/*.{js,ts,jsx,tsx}' --report-unused-disable-directives --max-warnings 0",

--- a/packages/babel-plugin/src/__test__/__snapshots__/component.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/component.test.ts.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`headless component > using default props should match snapshot 1`] = `
+"
+.🐻-1587700805 { color: green;text-decoration: line-through;font-size: 16px; }
+
+import { Box as __Box } from \\"@kuma-ui/core\\";
+import React from \\"react\\";
+import { Text } from '@kuma-ui/core';
+function App() {
+  return <Text className={\\"🐻-1587700805\\"} />;
+}
+"
+`;

--- a/packages/babel-plugin/src/__test__/__snapshots__/component.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/component.test.ts.snap
@@ -12,3 +12,16 @@ function App() {
 }
 "
 `;
+
+exports[`headless component > using default props with inline props should match snapshot 1`] = `
+"
+.🐻-4138457428 { color: blue;text-decoration: line-through;font-size: 12px; }
+
+import { Box as __Box } from \\"@kuma-ui/core\\";
+import React from \\"react\\";
+import { Text } from '@kuma-ui/core';
+function App() {
+  return <Text className={\\"🐻-4138457428\\"} />;
+}
+"
+`;

--- a/packages/babel-plugin/src/__test__/component.test.ts
+++ b/packages/babel-plugin/src/__test__/component.test.ts
@@ -2,7 +2,7 @@ import { theme } from "@kuma-ui/sheet";
 import { babelTransform, getExpectSnapshot } from "./testUtils";
 
 describe("headless component", () => {
-  test("using default props should match snapshot", () => {
+  beforeAll(() => {
     theme.setUserTheme({
       components: {
         Text: {
@@ -25,11 +25,28 @@ describe("headless component", () => {
         },
       },
     });
+  });
+
+  test("using default props should match snapshot", () => {
     // Arrange
     const inputCode = `
         import { Text } from '@kuma-ui/core'
         function App() {
           return <Text />
+        }
+      `;
+    // Act
+    const result = babelTransform(inputCode);
+    // Assert
+    expect(getExpectSnapshot(result)).toMatchSnapshot();
+  });
+
+  test("using default props with inline props should match snapshot", () => {
+    // Arrange
+    const inputCode = `
+        import { Text } from '@kuma-ui/core'
+        function App() {
+          return <Text variant="secondary" fontSize="12px" />
         }
       `;
     // Act

--- a/packages/babel-plugin/src/__test__/component.test.ts
+++ b/packages/babel-plugin/src/__test__/component.test.ts
@@ -1,0 +1,40 @@
+import { theme } from "@kuma-ui/sheet";
+import { babelTransform, getExpectSnapshot } from "./testUtils";
+
+describe("headless component", () => {
+  test("using default props should match snapshot", () => {
+    theme.setUserTheme({
+      components: {
+        Text: {
+          baseStyle: {
+            textDecoration: "underline", // will be overwritten by defaultProps
+          },
+          variants: {
+            primary: {
+              color: "green",
+            },
+            secondary: {
+              color: "blue",
+            },
+          },
+          defaultProps: {
+            variant: "primary",
+            textDecoration: "line-through",
+            fontSize: "16px",
+          },
+        },
+      },
+    });
+    // Arrange
+    const inputCode = `
+        import { Text } from '@kuma-ui/core'
+        function App() {
+          return <Text />
+        }
+      `;
+    // Act
+    const result = babelTransform(inputCode);
+    // Assert
+    expect(getExpectSnapshot(result)).toMatchSnapshot();
+  });
+});

--- a/packages/compiler/src/extractor/extract.ts
+++ b/packages/compiler/src/extractor/extract.ts
@@ -37,7 +37,7 @@ export const extractProps = (
 
   const variant = theme.getVariants(componentName);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
-  const componentVariantProps: { [key: string]: any } = {
+  const baseStyleProps: { [key: string]: any } = {
     ...(variant?.baseStyle as Record<string, string>),
   };
 
@@ -59,7 +59,7 @@ export const extractProps = (
       componentProps[propName.trim()] = propValue;
     } else if (propName.trim() === "variant") {
       Object.assign(
-        componentVariantProps,
+        baseStyleProps,
         variant?.variants?.[propValue as string]
       );
       jsx.getAttribute("variant")?.remove();
@@ -83,14 +83,14 @@ export const extractProps = (
   // Every component internally uses the Box component.
   // However, we do not want to apply the Box theme in those cases.
   if (componentName === "Box" && isDefault) {
-    for (const prop in componentVariantProps) {
-      if (Object.hasOwn(componentVariantProps, prop)) {
-        delete componentVariantProps[prop];
+    for (const prop in baseStyleProps) {
+      if (Object.hasOwn(baseStyleProps, prop)) {
+        delete baseStyleProps[prop];
       }
     }
   }
   const combinedProps = {
-    ...componentVariantProps,
+    ...baseStyleProps,
     ...specificProps,
     ...styledProps,
     ...pseudoProps,

--- a/packages/compiler/src/extractor/extract.ts
+++ b/packages/compiler/src/extractor/extract.ts
@@ -41,12 +41,14 @@ export const extractProps = (
     ...(variant?.baseStyle as Record<string, string>),
   };
 
-  const defaultProps = componentDefaultProps(componentName);
+  const systemDefaultProps = componentDefaultProps(componentName);
+  const userDefaultProps = variant?.defaultProps;
 
   let isDefault = false;
 
   for (const [propName, propValue] of Object.entries({
-    ...defaultProps,
+    ...systemDefaultProps,
+    ...userDefaultProps,
     ...propsMap,
   })) {
     if (isStyledProp(propName.trim())) {

--- a/packages/core/src/components/types.ts
+++ b/packages/core/src/components/types.ts
@@ -57,7 +57,7 @@ type Variants<
   T,
   ComponentType extends keyof typeof componentList
 > = T extends Required<Required<ThemeInput>["components"]>[ComponentType]
-  ? T["variants"]
+  ? NonNullable<T["variants"]>
   : never;
 
 type Variant<ComponentType extends keyof typeof componentList> = If<

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,11 @@
 export { styled } from "./styled";
 export { k } from "./k";
 export { css } from "./css";
-export { createTheme, type Theme, type ThemeSystem } from "./theme";
+export {
+  createTheme,
+  createComponentTheme,
+  type Theme,
+  type ThemeSystem,
+} from "./theme";
 export * from "./components";
 export * from "./registry";

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -17,9 +17,12 @@ import { StyledProps, PseudoProps, ThemeSystemType } from "@kuma-ui/system";
 type StyleProps = StyledProps & PseudoProps;
 
 type RawThemeComponent = {
+  /**
+   * @deprecated use `defaultProps` instead
+   */
   baseStyle?: StyleProps;
   variants?: { [key: string]: StyleProps };
-  defaultProps?: { variant?: string } & Record<string, unknown>;
+  defaultProps?: { variant?: string } & StyleProps & Record<string, unknown>;
 };
 
 type RawThemeComponents = {

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -18,6 +18,7 @@ export type ThemeInput = InputThemeTokens & {
     [_ in keyof typeof componentList]?: {
       baseStyle?: StyledProps;
       variants?: { [key: string]: StyledProps };
+      defaultProps?: { variant?: string };
     };
   };
 };
@@ -56,4 +57,16 @@ export function createTheme<const T extends ThemeInput>(
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
     components: components,
   } as unknown as ThemeResult<T>;
+}
+
+type ComponentThemeInput<Variants extends { [key: string]: StyledProps }> = {
+  baseStyle?: StyledProps;
+  variants?: Variants;
+  defaultProps?: StyledProps & { variant?: keyof Variants };
+};
+
+export function createComponentTheme<
+  const Variants extends { [key: string]: StyledProps }
+>(config: ComponentThemeInput<Variants>) {
+  return config;
 }

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -62,7 +62,7 @@ export function createTheme<const T extends ThemeInput>(
 type ComponentThemeInput<Variants extends { [key: string]: StyledProps }> = {
   baseStyle?: StyledProps;
   variants?: Variants;
-  defaultProps?: StyledProps & { variant?: keyof Variants };
+  defaultProps?: { variant?: keyof Variants } & Record<string, unknown>;
 };
 
 export function createComponentTheme<

--- a/packages/sheet/src/theme.ts
+++ b/packages/sheet/src/theme.ts
@@ -43,7 +43,7 @@ export type UserTheme = {
       baseStyle?: any;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
       variants?: { [key: string]: any };
-      defaultProps?: { variant?: string };
+      defaultProps?: { variant?: string } & Record<string, unknown>;
     };
   };
 };

--- a/packages/sheet/src/theme.ts
+++ b/packages/sheet/src/theme.ts
@@ -94,7 +94,6 @@ export class Theme {
               [key: string]: any;
             }
           | undefined;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
         defaultProps?: { variant?: string };
       }
     | undefined {

--- a/packages/sheet/src/theme.ts
+++ b/packages/sheet/src/theme.ts
@@ -43,6 +43,7 @@ export type UserTheme = {
       baseStyle?: any;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
       variants?: { [key: string]: any };
+      defaultProps?: { variant?: string };
     };
   };
 };
@@ -93,6 +94,8 @@ export class Theme {
               [key: string]: any;
             }
           | undefined;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
+        defaultProps?: { variant?: string };
       }
     | undefined {
     return this._userTheme.components?.[componentName] || {};

--- a/packages/sheet/src/theme.ts
+++ b/packages/sheet/src/theme.ts
@@ -94,7 +94,7 @@ export class Theme {
               [key: string]: any;
             }
           | undefined;
-        defaultProps?: { variant?: string };
+        defaultProps?: { variant?: string } & Record<string, unknown>;
       }
     | undefined {
     return this._userTheme.components?.[componentName] || {};

--- a/website/src/pages/docs/Theme/ComponentTheme.mdx
+++ b/website/src/pages/docs/Theme/ComponentTheme.mdx
@@ -4,6 +4,7 @@ description: "Get to know how to customize component-specific themes in Kuma UI"
 ---
 
 import { PrimaryButton, ExampleContainer } from "../../../components/example";
+import { Callout } from "nextra-theme-docs";
 
 # Component Theme
 
@@ -11,24 +12,36 @@ In Kuma UI, you can define default and variant styles for your components global
 
 ## Defining Component Styles
 
-Component styles are defined in the `components` field of your theme. Each component can have a `baseStyle` and `variants`.
+Component styles are defined in the `components` field of your theme. Each component can have a `defaultProps` and `variants`.
 
-Here's an example of how you can define a `primary` variant for the `Button` component:
+<Callout type="warning">
+  You can also define `baseStyle` for each component but it's deprecated and
+  will be removed in v2.0. Use `defaultProps` instead.
+</Callout>
+
+Here's an example of how you can define a `primary` variant and make it default for the `Button` component:
 
 ```ts
 const theme = createTheme({
   components: {
     Button: {
+      defaultProps: {
+        variant: "primary",
+        borderRadius: "14px",
+        p: "16px 32px",
+        fontWeight: 600,
+        _hover: {
+          opacity: 0.8,
+        },
+      },
       variants: {
         primary: {
           bg: "#576ddf",
-          borderRadius: "14px",
-          p: "16px 32px",
           color: "white",
-          fontWeight: 600,
-          _hover: {
-            opacity: 0.8,
-          },
+        },
+        secondary: {
+          bg: "white",
+          color: "#576ddf",
         },
       },
     },

--- a/website/src/pages/docs/Theme/CustomizingTheme.mdx
+++ b/website/src/pages/docs/Theme/CustomizingTheme.mdx
@@ -33,7 +33,7 @@ const theme = createTheme({
   },
   components: {
     Button: {
-      baseStyle: {
+      defaultProps: {
         bg: "black", // bg is short for background
         p: "10px", // p is short for padding
       },


### PR DESCRIPTION
#303

Introduce `defaultProps` to allow users to define default properties for each component.

### Example

```js
const theme = createTheme({
  components: {
    Text: {
      baseStyle: {
        textDecoration: "underline",
      },
      variants: {
        primary: {
          color: "green",
        },
        secondary: {
          color: "blue",
        },
      },
      defaultProps: {
        variant: "primary",
        textDecoration: "line-through",
        fontSize: "16px",
      },
    },
  },
});
```

Then the CSS for `<Text />` will be like `{ color: green;text-decoration: line-through;font-size: 16px; }`.