### PR TITLE
fix(vite): fix incorrect exports.types path

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -19,7 +19,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.mjs",
     "require": "./dist/index.js"
   },


### PR DESCRIPTION
## Summary
This Pull Request addresses the issue of an incorrect `exports.types` path specified in the `packages.json` file.

## Background
The current incorrect path specification is causing issues with referencing TypeScript type definition files. This fix ensures that the correct type definition files are accessible.
<img width="1305" alt="スクリーンショット 2023-08-26 23 26 19" src="https://github.com/kuma-ui/kuma-ui/assets/57742720/8121f496-a511-458b-9c6a-3e41b6f6a39e">

## Changes Made
The correct `exports.types` path has been updated.