### PR TITLE
Exclude vitest.setup.ts from dist files

### DIFF
--- a/.changeset/young-boats-perform.md
+++ b/.changeset/young-boats-perform.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/core": patch
+---
+
+Exclude vitest.setup.ts from dist files

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -7,13 +7,23 @@ export default defineConfig([
     clean: true,
     dts: true,
     format: ["cjs"],
-    entry: ["src", "!src/**/*.test.*", "!src/**__test__/**"],
+    entry: [
+      "src",
+      "!src/**/*.test.*",
+      "!src/**__test__/**",
+      "!src/**/vitest.setup.ts",
+    ],
     bundle: false,
   },
   {
     clean: true,
     format: ["esm"],
-    entry: ["src", "!src/**/*.test.*", "!src/**__test__/**"],
+    entry: [
+      "src",
+      "!src/**/*.test.*",
+      "!src/**__test__/**",
+      "!src/**/vitest.setup.ts",
+    ],
     bundle: true,
     esbuildPlugins: [
       {


### PR DESCRIPTION
`vitest.setup.ts` is unnecessary for users but wrongly included in the distribution. This PR removes it.

<img width="794" alt="image" src="https://github.com/kuma-ui/kuma-ui/assets/16265411/be61af74-3409-4a12-9076-c876117d5e4c">
