### PR TITLE
Run CI with node v18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: [16]
+        node_version: [16, 18]
         os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout
@@ -41,7 +41,7 @@ jobs:
 
       - uses: ./.github/actions/setup-pnpm
         with:
-          node_version: 16
+          node_version: 18
 
       - name: Build packages
         run: pnpm build
@@ -61,7 +61,7 @@ jobs:
 
       - uses: ./.github/actions/setup-pnpm
         with:
-          node_version: 16
+          node_version: 18
 
       - name: Run changeset status
         run: pnpm changeset status --since origin/main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,18 +5,15 @@ on:
       - main
 jobs:
   release:
-    name: Node ${{ matrix.node_version }} releasing
+    name: Release
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node_version: [16]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - uses: ./.github/actions/setup-pnpm
         with:
-          node_version: ${{ matrix.node_version }}
+          node_version: 18
 
       - name: build packages
         run: pnpm run build


### PR DESCRIPTION
Use current LTS Node.js v18 to make build faster and ensure kuma works on v18