### PR TITLE
#318 Theme tokens support

### DIFF
--- a/.changeset/friendly-horses-cough.md
+++ b/.changeset/friendly-horses-cough.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/sheet": minor
+---
+
+Added placeholder support for tokens in css t("colors.primary")

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage/
 node_modules/
 .vscode
 .env
+.idea/

--- a/packages/babel-plugin/src/__test__/css.test.ts
+++ b/packages/babel-plugin/src/__test__/css.test.ts
@@ -2,8 +2,19 @@
 /// <reference types="vitest/globals" />
 
 import { babelTransform, getExpectSnapshot } from "./testUtils";
+import { sheet, theme } from "@kuma-ui/sheet";
+import { beforeEach } from "vitest";
 
 describe("css function", () => {
+  beforeEach(() => {
+    sheet.reset();
+    theme.setUserTheme({
+      colors: {
+        "colors.primary": "red",
+      },
+    });
+  });
+
   describe("Snapshot tests", () => {
     test("basic usage should match snapshot", () => {
       // Arrange
@@ -43,6 +54,25 @@ describe("css function", () => {
       const result = babelTransform(inputCode);
       // Assert
       expect(getExpectSnapshot(result)).toMatchSnapshot();
+    });
+
+    test("placeholder usage should match snapshot", () => {
+      // Arrange
+      const originalCode = `
+        import { css } from '@kuma-ui/core'
+        const style = css\`color: red;\`
+      `;
+      const inputCode = `
+        import { css } from '@kuma-ui/core'
+        const style = css\`color: t("colors.primary");\`
+      `;
+      // Act
+      const result = babelTransform(inputCode);
+      const originalResult = babelTransform(originalCode);
+      // Assert
+      expect(getExpectSnapshot(result)).toEqual(
+        getExpectSnapshot(originalResult)
+      );
     });
   });
 });

--- a/packages/babel-plugin/src/__test__/styled.test.ts
+++ b/packages/babel-plugin/src/__test__/styled.test.ts
@@ -1,6 +1,20 @@
 import { babelTransform, getExpectSnapshot } from "./testUtils";
+import { beforeEach } from "vitest";
+import { sheet, theme } from "@kuma-ui/sheet";
 
 describe("styled function", () => {
+  beforeEach(() => {
+    sheet.reset();
+    theme.setUserTheme({
+      colors: {
+        "colors.background": "rgba(255, 0, 0, 0.5)",
+      },
+      breakpoints: {
+        "breakpoints.sm": "768px",
+      },
+    });
+  });
+
   describe.each([[undefined], ["classic" as const], ["automatic" as const]])(
     "Snapshot tests (runtime: %s)",
     () => {
@@ -28,6 +42,52 @@ describe("styled function", () => {
         const result = babelTransform(inputCode);
         // Assert
         expect(getExpectSnapshot(result)).toMatchSnapshot();
+      });
+
+      test("placeholder usage should match snapshot", () => {
+        const originalCode = `
+        import { styled } from '@kuma-ui/core'
+        const Box = styled('div')\`
+          position: relative;
+          width: 300px;
+          height: 300px;
+          background-color: rgba(255, 0, 0, 0.5);
+          &:hover {
+            background-color: rgba(0, 0, 255, 0.5);
+          }
+          @media (max-width: 768px) {
+            flex-direction: column;
+          }
+        \`
+        function App() {
+          return <Box>test</Box>
+        }
+      `;
+
+        // Arrange
+        const inputCode = `
+        import { styled } from '@kuma-ui/core'
+        const Box = styled('div')\`
+          position: relative;
+          width: 300px;
+          height: 300px;
+          background-color: t("colors.background");
+          &:hover {
+            background-color: rgba(0, 0, 255, 0.5);
+          }
+          @media (max-width: t("breakpoints.sm")) {
+            flex-direction: column;
+          }
+        \`
+        function App() {
+          return <Box>test</Box>
+        }
+      `;
+        // Act
+        const result = babelTransform(inputCode);
+        const original = babelTransform(originalCode);
+        // Assert
+        expect(getExpectSnapshot(result)).toEqual(getExpectSnapshot(original));
       });
 
       test("using pseudo elements should match snapshot", () => {

--- a/packages/sheet/src/placeholders.test.ts
+++ b/packages/sheet/src/placeholders.test.ts
@@ -1,0 +1,262 @@
+import {
+  applyPlaceholders,
+  applySpacingScalingFactor,
+  createPlaceholders,
+  applyT,
+  applyArrayT,
+} from "./placeholders";
+import { describe, expect, it } from "vitest";
+import { UserTheme } from "./theme";
+
+describe("Theme utility functions", () => {
+  describe("applyPlaceholders", () => {
+    it("replaces valid placeholders", () => {
+      const input = "Color is t('c.primary') and breakpoint is t('b.mobile')";
+      const placeholders = {
+        "c.primary": "#FF0000",
+        "b.mobile": "480px",
+      };
+      expect(applyPlaceholders(input, placeholders)).toBe(
+        "Color is #FF0000 and breakpoint is 480px"
+      );
+    });
+
+    it("ignores invalid placeholders", () => {
+      const input = "Color is t('c.primary') and something is t('invalid.key')";
+      const placeholders = {
+        "c.primary": "#FF0000",
+      };
+      expect(applyPlaceholders(input, placeholders)).toBe(
+        "Color is #FF0000 and something is t('invalid.key')"
+      );
+    });
+  });
+
+  describe("applySpacingScalingFactor", () => {
+    it("replaces integers with scaled px value", () => {
+      const input = "Margin is t(2)";
+      expect(applySpacingScalingFactor(input, 8)).toBe("Margin is 16px");
+    });
+
+    it("replaces decimals with scaled px value", () => {
+      const input = "Padding is t(2.5)";
+      expect(applySpacingScalingFactor(input, 8)).toBe("Padding is 20px");
+    });
+
+    it("ignores non-number values", () => {
+      const input = "Something is t(notANumber)";
+      expect(applySpacingScalingFactor(input, 8)).toBe(
+        "Something is t(notANumber)"
+      );
+    });
+  });
+
+  describe("createPlaceholders", () => {
+    it("creates placeholders for valid theme values", () => {
+      const theme: Partial<UserTheme> = {
+        colors: {
+          primary: "#FF0000",
+        },
+        breakpoints: {
+          mobile: "480px",
+        },
+      };
+
+      expect(createPlaceholders(theme)).toEqual({
+        "colors.primary": "#FF0000",
+        "c.primary": "#FF0000",
+        "breakpoints.mobile": "480px",
+        "b.mobile": "480px",
+      });
+    });
+
+    it("ignores invalid or non-existent theme values", () => {
+      const theme: Partial<UserTheme> = {
+        colors: {
+          primary: "#FF0000",
+        },
+      };
+
+      expect(createPlaceholders(theme)).toEqual({
+        "colors.primary": "#FF0000",
+        "c.primary": "#FF0000",
+      });
+    });
+  });
+
+  describe("applyPlaceholders edge cases", () => {
+    it("handles empty strings", () => {
+      const placeholders = { "c.primary": "#FF0000" };
+      expect(applyPlaceholders("", placeholders)).toBe("");
+    });
+
+    it("handles strings without placeholders", () => {
+      const placeholders = { "c.primary": "#FF0000" };
+      expect(applyPlaceholders("No placeholders here", placeholders)).toBe(
+        "No placeholders here"
+      );
+    });
+
+    it("replaces multiple occurrences of the same placeholder", () => {
+      const placeholders = { "c.primary": "#FF0000" };
+      expect(
+        applyPlaceholders(
+          "Color t('c.primary') and again t('c.primary')",
+          placeholders
+        )
+      ).toBe("Color #FF0000 and again #FF0000");
+    });
+
+    it("handles a mixture of valid and invalid placeholders", () => {
+      const placeholders = { "c.primary": "#FF0000" };
+      expect(
+        applyPlaceholders(
+          "Colors: t('c.primary'), t('c.secondary')",
+          placeholders
+        )
+      ).toBe("Colors: #FF0000, t('c.secondary')");
+    });
+  });
+
+  describe("applySpacingScalingFactor edge cases", () => {
+    it("handles negative numbers", () => {
+      expect(applySpacingScalingFactor("Margin is t(-2)", 8)).toBe(
+        "Margin is -16px"
+      );
+    });
+
+    it("handles zero", () => {
+      expect(applySpacingScalingFactor("Padding is t(0)", 8)).toBe(
+        "Padding is 0px"
+      );
+    });
+
+    it("handles very large numbers", () => {
+      expect(applySpacingScalingFactor("Width is t(1000)", 8)).toBe(
+        "Width is 8000px"
+      );
+    });
+
+    it("handles multiple spacing factors", () => {
+      expect(
+        applySpacingScalingFactor("Margin is t(2) and padding is t(2.5)", 8)
+      ).toBe("Margin is 16px and padding is 20px");
+    });
+
+    it("handles whitespace around numbers", () => {
+      expect(applySpacingScalingFactor("Margin is t( 2 )", 8)).toBe(
+        "Margin is 16px"
+      );
+      expect(applySpacingScalingFactor("Padding is t( 2.5 )", 8)).toBe(
+        "Padding is 20px"
+      );
+    });
+  });
+
+  describe("createPlaceholders edge cases", () => {
+    it("handles empty theme", () => {
+      const theme: Partial<UserTheme> = {};
+      expect(createPlaceholders(theme)).toEqual({});
+    });
+
+    it("handles tokens without synonyms", () => {
+      const theme: Partial<UserTheme> = {
+        fontSizes: {
+          small: "12px",
+        },
+      };
+      expect(createPlaceholders(theme)).toEqual({ "fontSizes.small": "12px" });
+    });
+
+    it("handles whitespace around placeholders", () => {
+      const placeholders = { "c.primary": "#FF0000" };
+      expect(applyPlaceholders("Color t(  'c.primary'  )", placeholders)).toBe(
+        "Color #FF0000"
+      );
+      expect(applyPlaceholders('Color t(  "c.primary"  )', placeholders)).toBe(
+        "Color #FF0000"
+      );
+    });
+
+    it("handles both single and double quotation marks", () => {
+      const placeholders = { "c.primary": "#FF0000", "b.mobile": "480px" };
+      expect(applyPlaceholders('Color is t("c.primary")', placeholders)).toBe(
+        "Color is #FF0000"
+      );
+      expect(
+        applyPlaceholders("Breakpoint is t('b.mobile')", placeholders)
+      ).toBe("Breakpoint is 480px");
+    });
+  });
+
+  describe("applyT function", () => {
+    const theme: UserTheme = {
+      colors: {
+        primary: "#FF0000",
+        secondary: "#00FF00",
+      },
+      breakpoints: {
+        mobile: "480px",
+      },
+    };
+
+    const placeholders = createPlaceholders(theme);
+
+    it("should replace placeholders correctly", () => {
+      const input =
+        "Background is t('c.primary') and breakpoint is t('b.mobile')";
+      const result = applyT(input, placeholders, 8);
+      expect(result).toBe("Background is #FF0000 and breakpoint is 480px");
+    });
+
+    it("should handle spacing scaling factor for positive numbers", () => {
+      const input = "Margin is t(2)";
+      const result = applyT(input, placeholders, 8);
+      expect(result).toBe("Margin is 16px");
+    });
+
+    it("should handle spacing scaling factor for negative numbers", () => {
+      const input = "Margin is t(-2)";
+      const result = applyT(input, placeholders, 8);
+      expect(result).toBe("Margin is -16px");
+    });
+
+    it("should handle decimals in spacing scaling", () => {
+      const input = "Padding is t(1.5)";
+      const result = applyT(input, placeholders, 8);
+      expect(result).toBe("Padding is 12px");
+    });
+
+    it("should handle whitespaces and both single and double quotation marks", () => {
+      const input = 'Color is t("c.primary") and space is t( 1 )';
+      const result = applyT(input, placeholders, 8);
+      expect(result).toBe("Color is #FF0000 and space is 8px");
+    });
+
+    it("should leave unchanged values when there's no matching placeholder", () => {
+      const input = "This is a t('non.existent') placeholder";
+      const result = applyT(input, placeholders, 8);
+      expect(result).toBe("This is a t('non.existent') placeholder");
+    });
+
+    it("should process an array of strings correctly", () => {
+      const input = [
+        "Background is t('c.primary')",
+        "Margin is t(2)",
+        "Padding is t(1.5)",
+      ];
+      const result = applyArrayT(input, placeholders, 8);
+      expect(result).toEqual([
+        "Background is #FF0000",
+        "Margin is 16px",
+        "Padding is 12px",
+      ]);
+    });
+
+    it("should leave unchanged values in an array when there's no matching placeholder", () => {
+      const input = ["This is t('non.existent')", "Padding is t(1.5)"];
+      const result = applyArrayT(input, placeholders, 8);
+      expect(result).toEqual(["This is t('non.existent')", "Padding is 12px"]);
+    });
+  });
+});

--- a/packages/sheet/src/placeholders.test.ts
+++ b/packages/sheet/src/placeholders.test.ts
@@ -5,10 +5,11 @@ import { UserTheme } from "./theme";
 describe("Theme utility functions", () => {
   describe("applyPlaceholders", () => {
     it("replaces valid placeholders", () => {
-      const input = "Color is t('c.primary') and breakpoint is t('b.mobile')";
+      const input =
+        "Color is t('colors.primary') and breakpoint is t('breakpoints.mobile')";
       const placeholders = {
-        "c.primary": "#FF0000",
-        "b.mobile": "480px",
+        "colors.primary": "#FF0000",
+        "breakpoints.mobile": "480px",
       };
       expect(applyPlaceholders(input, placeholders)).toBe(
         "Color is #FF0000 and breakpoint is 480px"
@@ -16,9 +17,10 @@ describe("Theme utility functions", () => {
     });
 
     it("ignores invalid placeholders", () => {
-      const input = "Color is t('c.primary') and something is t('invalid.key')";
+      const input =
+        "Color is t('colors.primary') and something is t('invalid.key')";
       const placeholders = {
-        "c.primary": "#FF0000",
+        "colors.primary": "#FF0000",
       };
       expect(applyPlaceholders(input, placeholders)).toBe(
         "Color is #FF0000 and something is t('invalid.key')"
@@ -30,10 +32,10 @@ describe("Theme utility functions", () => {
     it("creates placeholders for valid theme values", () => {
       const theme: Partial<UserTheme> = {
         colors: {
-          primary: "#FF0000",
+          "colors.primary": "#FF0000",
         },
         breakpoints: {
-          mobile: "480px",
+          "breakpoints.mobile": "480px",
         },
       };
 
@@ -46,7 +48,7 @@ describe("Theme utility functions", () => {
     it("ignores invalid or non-existent theme values", () => {
       const theme: Partial<UserTheme> = {
         colors: {
-          primary: "#FF0000",
+          "colors.primary": "#FF0000",
         },
       };
 
@@ -58,35 +60,35 @@ describe("Theme utility functions", () => {
 
   describe("applyPlaceholders edge cases", () => {
     it("handles empty strings", () => {
-      const placeholders = { "c.primary": "#FF0000" };
+      const placeholders = { "colors.primary": "#FF0000" };
       expect(applyPlaceholders("", placeholders)).toBe("");
     });
 
     it("handles strings without placeholders", () => {
-      const placeholders = { "c.primary": "#FF0000" };
+      const placeholders = { "colors.primary": "#FF0000" };
       expect(applyPlaceholders("No placeholders here", placeholders)).toBe(
         "No placeholders here"
       );
     });
 
     it("replaces multiple occurrences of the same placeholder", () => {
-      const placeholders = { "c.primary": "#FF0000" };
+      const placeholders = { "colors.primary": "#FF0000" };
       expect(
         applyPlaceholders(
-          "Color t('c.primary') and again t('c.primary')",
+          "Color t('colors.primary') and again t('colors.primary')",
           placeholders
         )
       ).toBe("Color #FF0000 and again #FF0000");
     });
 
     it("handles a mixture of valid and invalid placeholders", () => {
-      const placeholders = { "c.primary": "#FF0000" };
+      const placeholders = { "colors.primary": "#FF0000" };
       expect(
         applyPlaceholders(
-          "Colors: t('c.primary'), t('c.secondary')",
+          "Colors: t('colors.primary'), t('colors.secondary')",
           placeholders
         )
-      ).toBe("Colors: #FF0000, t('c.secondary')");
+      ).toBe("Colors: #FF0000, t('colors.secondary')");
     });
   });
 
@@ -99,29 +101,32 @@ describe("Theme utility functions", () => {
     it("handles tokens without synonyms", () => {
       const theme: Partial<UserTheme> = {
         fontSizes: {
-          small: "12px",
+          "fontSizes.small": "12px",
         },
       };
       expect(createPlaceholders(theme)).toEqual({ "fontSizes.small": "12px" });
     });
 
     it("handles whitespace around placeholders", () => {
-      const placeholders = { "c.primary": "#FF0000" };
-      expect(applyPlaceholders("Color t(  'c.primary'  )", placeholders)).toBe(
-        "Color #FF0000"
-      );
-      expect(applyPlaceholders('Color t(  "c.primary"  )', placeholders)).toBe(
-        "Color #FF0000"
-      );
+      const placeholders = { "colors.primary": "#FF0000" };
+      expect(
+        applyPlaceholders("Color t(  'colors.primary'  )", placeholders)
+      ).toBe("Color #FF0000");
+      expect(
+        applyPlaceholders('Color t(  "colors.primary"  )', placeholders)
+      ).toBe("Color #FF0000");
     });
 
     it("handles both single and double quotation marks", () => {
-      const placeholders = { "c.primary": "#FF0000", "b.mobile": "480px" };
-      expect(applyPlaceholders('Color is t("c.primary")', placeholders)).toBe(
-        "Color is #FF0000"
-      );
+      const placeholders = {
+        "colors.primary": "#FF0000",
+        "breakpoints.mobile": "480px",
+      };
       expect(
-        applyPlaceholders("Breakpoint is t('b.mobile')", placeholders)
+        applyPlaceholders('Color is t("colors.primary")', placeholders)
+      ).toBe("Color is #FF0000");
+      expect(
+        applyPlaceholders("Breakpoint is t('breakpoints.mobile')", placeholders)
       ).toBe("Breakpoint is 480px");
     });
   });
@@ -129,11 +134,11 @@ describe("Theme utility functions", () => {
   describe("applyT function", () => {
     const theme: UserTheme = {
       colors: {
-        primary: "#FF0000",
-        secondary: "#00FF00",
+        "colors.primary": "#FF0000",
+        "colors.secondary": "#00FF00",
       },
       breakpoints: {
-        mobile: "480px",
+        "breakpoints.mobile": "480px",
       },
     };
 

--- a/packages/sheet/src/placeholders.test.ts
+++ b/packages/sheet/src/placeholders.test.ts
@@ -3,7 +3,6 @@ import {
   applySpacingScalingFactor,
   createPlaceholders,
   applyT,
-  applyArrayT,
 } from "./placeholders";
 import { describe, expect, it } from "vitest";
 import { UserTheme } from "./theme";
@@ -237,26 +236,6 @@ describe("Theme utility functions", () => {
       const input = "This is a t('non.existent') placeholder";
       const result = applyT(input, placeholders, 8);
       expect(result).toBe("This is a t('non.existent') placeholder");
-    });
-
-    it("should process an array of strings correctly", () => {
-      const input = [
-        "Background is t('c.primary')",
-        "Margin is t(2)",
-        "Padding is t(1.5)",
-      ];
-      const result = applyArrayT(input, placeholders, 8);
-      expect(result).toEqual([
-        "Background is #FF0000",
-        "Margin is 16px",
-        "Padding is 12px",
-      ]);
-    });
-
-    it("should leave unchanged values in an array when there's no matching placeholder", () => {
-      const input = ["This is t('non.existent')", "Padding is t(1.5)"];
-      const result = applyArrayT(input, placeholders, 8);
-      expect(result).toEqual(["This is t('non.existent')", "Padding is 12px"]);
     });
   });
 });

--- a/packages/sheet/src/placeholders.test.ts
+++ b/packages/sheet/src/placeholders.test.ts
@@ -1,9 +1,4 @@
-import {
-  applyPlaceholders,
-  applySpacingScalingFactor,
-  createPlaceholders,
-  applyT,
-} from "./placeholders";
+import { applyPlaceholders, createPlaceholders, applyT } from "./placeholders";
 import { describe, expect, it } from "vitest";
 import { UserTheme } from "./theme";
 
@@ -31,25 +26,6 @@ describe("Theme utility functions", () => {
     });
   });
 
-  describe("applySpacingScalingFactor", () => {
-    it("replaces integers with scaled px value", () => {
-      const input = "Margin is t(2)";
-      expect(applySpacingScalingFactor(input, 8)).toBe("Margin is 16px");
-    });
-
-    it("replaces decimals with scaled px value", () => {
-      const input = "Padding is t(2.5)";
-      expect(applySpacingScalingFactor(input, 8)).toBe("Padding is 20px");
-    });
-
-    it("ignores non-number values", () => {
-      const input = "Something is t(notANumber)";
-      expect(applySpacingScalingFactor(input, 8)).toBe(
-        "Something is t(notANumber)"
-      );
-    });
-  });
-
   describe("createPlaceholders", () => {
     it("creates placeholders for valid theme values", () => {
       const theme: Partial<UserTheme> = {
@@ -63,9 +39,7 @@ describe("Theme utility functions", () => {
 
       expect(createPlaceholders(theme)).toEqual({
         "colors.primary": "#FF0000",
-        "c.primary": "#FF0000",
         "breakpoints.mobile": "480px",
-        "b.mobile": "480px",
       });
     });
 
@@ -78,7 +52,6 @@ describe("Theme utility functions", () => {
 
       expect(createPlaceholders(theme)).toEqual({
         "colors.primary": "#FF0000",
-        "c.primary": "#FF0000",
       });
     });
   });
@@ -114,41 +87,6 @@ describe("Theme utility functions", () => {
           placeholders
         )
       ).toBe("Colors: #FF0000, t('c.secondary')");
-    });
-  });
-
-  describe("applySpacingScalingFactor edge cases", () => {
-    it("handles negative numbers", () => {
-      expect(applySpacingScalingFactor("Margin is t(-2)", 8)).toBe(
-        "Margin is -16px"
-      );
-    });
-
-    it("handles zero", () => {
-      expect(applySpacingScalingFactor("Padding is t(0)", 8)).toBe(
-        "Padding is 0px"
-      );
-    });
-
-    it("handles very large numbers", () => {
-      expect(applySpacingScalingFactor("Width is t(1000)", 8)).toBe(
-        "Width is 8000px"
-      );
-    });
-
-    it("handles multiple spacing factors", () => {
-      expect(
-        applySpacingScalingFactor("Margin is t(2) and padding is t(2.5)", 8)
-      ).toBe("Margin is 16px and padding is 20px");
-    });
-
-    it("handles whitespace around numbers", () => {
-      expect(applySpacingScalingFactor("Margin is t( 2 )", 8)).toBe(
-        "Margin is 16px"
-      );
-      expect(applySpacingScalingFactor("Padding is t( 2.5 )", 8)).toBe(
-        "Padding is 20px"
-      );
     });
   });
 
@@ -201,40 +139,33 @@ describe("Theme utility functions", () => {
 
     const placeholders = createPlaceholders(theme);
 
-    it("should replace placeholders correctly", () => {
-      const input =
-        "Background is t('c.primary') and breakpoint is t('b.mobile')";
-      const result = applyT(input, placeholders, 8);
-      expect(result).toBe("Background is #FF0000 and breakpoint is 480px");
-    });
-
     it("should handle spacing scaling factor for positive numbers", () => {
       const input = "Margin is t(2)";
-      const result = applyT(input, placeholders, 8);
-      expect(result).toBe("Margin is 16px");
+      const result = applyT(input, placeholders);
+      expect(result).toBe("Margin is t(2)");
     });
 
     it("should handle spacing scaling factor for negative numbers", () => {
       const input = "Margin is t(-2)";
-      const result = applyT(input, placeholders, 8);
-      expect(result).toBe("Margin is -16px");
+      const result = applyT(input, placeholders);
+      expect(result).toBe("Margin is t(-2)");
     });
 
     it("should handle decimals in spacing scaling", () => {
       const input = "Padding is t(1.5)";
-      const result = applyT(input, placeholders, 8);
-      expect(result).toBe("Padding is 12px");
+      const result = applyT(input, placeholders);
+      expect(result).toBe("Padding is t(1.5)");
     });
 
     it("should handle whitespaces and both single and double quotation marks", () => {
-      const input = 'Color is t("c.primary") and space is t( 1 )';
-      const result = applyT(input, placeholders, 8);
-      expect(result).toBe("Color is #FF0000 and space is 8px");
+      const input = 'Color is t( "colors.primary" ) and space is t( 1 )';
+      const result = applyT(input, placeholders);
+      expect(result).toBe("Color is #FF0000 and space is t( 1 )");
     });
 
     it("should leave unchanged values when there's no matching placeholder", () => {
       const input = "This is a t('non.existent') placeholder";
-      const result = applyT(input, placeholders, 8);
+      const result = applyT(input, placeholders);
       expect(result).toBe("This is a t('non.existent') placeholder");
     });
   });

--- a/packages/sheet/src/placeholders.ts
+++ b/packages/sheet/src/placeholders.ts
@@ -1,0 +1,99 @@
+import { Tokens, UserTheme } from "./theme";
+
+const tokens: Tokens[] = [
+  "colors",
+  "fonts",
+  "fontSizes",
+  "fontWeights",
+  "lineHeights",
+  "letterSpacings",
+  "spacings",
+  "sizes",
+  "radii",
+  "zIndices",
+  "breakpoints",
+];
+
+const synonyms: Partial<Record<Tokens, string>> = {
+  breakpoints: "b",
+  colors: "c",
+};
+
+export interface Placeholders {
+  [key: string]: string;
+}
+
+export const applyT = (
+  input: string,
+  placeholders: Placeholders,
+  factor: number
+): string => {
+  return applySpacingScalingFactor(
+    applyPlaceholders(input, placeholders),
+    factor
+  );
+};
+
+export const applyArrayT = (
+  input: string | string[],
+  placeholders: Placeholders,
+  factor: number
+): string | string[] => {
+  if (typeof input === "string") {
+    return applyT(input, placeholders, factor);
+  } else if (Array.isArray(input)) {
+    return input.map((str) => applyT(str, placeholders, factor));
+  }
+
+  throw new Error("Invalid input type. Expected string or string[].");
+};
+
+export const applyPlaceholders = (
+  input: string,
+  placeholders: Placeholders
+): string => {
+  const regex = /\bt\s*\(\s*["']([^"']+)["']\s*\)/g;
+
+  return input.replace(regex, (match, placeholder) => {
+    if (typeof placeholder === "string" && placeholder in placeholders) {
+      return placeholders[placeholder];
+    }
+    return match; // return the original match if there's no substitution
+  });
+};
+
+export const applySpacingScalingFactor = (
+  input: string,
+  factor: number
+): string => {
+  const regex = /\bt\s*\(\s*(-?\d+(\.\d+)?)\s*\)/g;
+
+  return input.replace(regex, (match, number: string) => {
+    const parsedValue = parseFloat(number);
+    if (!isNaN(parsedValue)) {
+      const multipliedValue = parsedValue * factor;
+      return `${multipliedValue}px`;
+    }
+    return match;
+  });
+};
+
+export const createPlaceholders = (
+  theme: Partial<UserTheme>
+): Record<string, string> => {
+  const result: Record<string, string> = {};
+
+  for (const token of tokens) {
+    const tokenValue = theme[token];
+    if (tokenValue) {
+      for (const key in tokenValue) {
+        result[`${token}.${key}`] = tokenValue[key]; // Add the token itself
+        if (synonyms[token]) {
+          result[`${synonyms[token]}.${key}`] = tokenValue[key]; // Add the synonym if it exists
+        }
+      }
+    }
+  }
+
+  return result;
+};

--- a/packages/sheet/src/placeholders.ts
+++ b/packages/sheet/src/placeholders.ts
@@ -34,20 +34,6 @@ export const applyT = (
   );
 };
 
-export const applyArrayT = (
-  input: string | string[],
-  placeholders: Placeholders,
-  factor: number
-): string | string[] => {
-  if (typeof input === "string") {
-    return applyT(input, placeholders, factor);
-  } else if (Array.isArray(input)) {
-    return input.map((str) => applyT(str, placeholders, factor));
-  }
-
-  throw new Error("Invalid input type. Expected string or string[].");
-};
-
 export const applyPlaceholders = (
   input: string,
   placeholders: Placeholders

--- a/packages/sheet/src/placeholders.ts
+++ b/packages/sheet/src/placeholders.ts
@@ -1,37 +1,11 @@
-import { Tokens, UserTheme } from "./theme";
-
-const tokens: Tokens[] = [
-  "colors",
-  "fonts",
-  "fontSizes",
-  "fontWeights",
-  "lineHeights",
-  "letterSpacings",
-  "spacings",
-  "sizes",
-  "radii",
-  "zIndices",
-  "breakpoints",
-];
-
-const synonyms: Partial<Record<Tokens, string>> = {
-  breakpoints: "b",
-  colors: "c",
-};
+import { Tokens, UserTheme, tokens } from "./theme";
 
 export interface Placeholders {
   [key: string]: string;
 }
 
-export const applyT = (
-  input: string,
-  placeholders: Placeholders,
-  factor: number
-): string => {
-  return applySpacingScalingFactor(
-    applyPlaceholders(input, placeholders),
-    factor
-  );
+export const applyT = (input: string, placeholders: Placeholders): string => {
+  return applyPlaceholders(input, placeholders);
 };
 
 export const applyPlaceholders = (
@@ -48,22 +22,6 @@ export const applyPlaceholders = (
   });
 };
 
-export const applySpacingScalingFactor = (
-  input: string,
-  factor: number
-): string => {
-  const regex = /\bt\s*\(\s*(-?\d+(\.\d+)?)\s*\)/g;
-
-  return input.replace(regex, (match, number: string) => {
-    const parsedValue = parseFloat(number);
-    if (!isNaN(parsedValue)) {
-      const multipliedValue = parsedValue * factor;
-      return `${multipliedValue}px`;
-    }
-    return match;
-  });
-};
-
 export const createPlaceholders = (
   theme: Partial<UserTheme>
 ): Record<string, string> => {
@@ -74,9 +32,6 @@ export const createPlaceholders = (
     if (tokenValue) {
       for (const key in tokenValue) {
         result[`${token}.${key}`] = tokenValue[key]; // Add the token itself
-        if (synonyms[token]) {
-          result[`${synonyms[token]}.${key}`] = tokenValue[key]; // Add the synonym if it exists
-        }
       }
     }
   }

--- a/packages/sheet/src/placeholders.ts
+++ b/packages/sheet/src/placeholders.ts
@@ -31,7 +31,7 @@ export const createPlaceholders = (
     const tokenValue = theme[token];
     if (tokenValue) {
       for (const key in tokenValue) {
-        result[`${token}.${key}`] = tokenValue[key]; // Add the token itself
+        result[key] = tokenValue[key]; // Add the token itself
       }
     }
   }

--- a/packages/sheet/src/sheet.test.ts
+++ b/packages/sheet/src/sheet.test.ts
@@ -1,6 +1,7 @@
 import { sheet, SystemStyle } from "./sheet";
-import { describe, expect, test, beforeEach } from "vitest";
+import { describe, expect, test, beforeEach, beforeAll } from "vitest";
 import { removeSpacesAroundCssPropertyValues } from "./regex";
+import { theme } from "./theme";
 
 describe("Sheet class", () => {
   beforeEach(() => {
@@ -79,5 +80,38 @@ describe("Sheet class", () => {
     const expectedCSS = `.${id}{color:red;}@media (min-width:768px){.${id}{color:blue;}}@media (min-width:768px){.${id}:hover{color:yellow;}}.${id}:hover{color:green;}`;
     // Assert
     expect(cssString).toEqual(expectedCSS);
+  });
+
+  describe("Sheet placeholders", () => {
+    beforeAll(() => {
+      theme.setUserTheme({
+        breakpoints: {
+          sm: "1000px",
+        },
+        colors: {
+          primary: "red",
+          secondary: "blue",
+        },
+        zIndices: {
+          modal: "1000",
+        },
+      });
+    });
+
+    test("parseCSS() support of t()", () => {
+      // Arrange
+      const style = `
+      color: t("colors.primary");
+      background-color: t('c.secondary');
+      @media (max-width: t("b.sm")) {
+        flex-direction: column;
+      }
+    `;
+      // Act
+      const className = sheet.parseCSS(style);
+      // Assert
+      const expectedCSS = `.${className}{color:red;background-color:blue;}@media (max-width: 1000px){.${className}{flex-direction:column;}}`;
+      expect(sheet.getCSS()).toEqual(expectedCSS);
+    });
   });
 });

--- a/packages/sheet/src/sheet.test.ts
+++ b/packages/sheet/src/sheet.test.ts
@@ -62,7 +62,6 @@ describe("Sheet class", () => {
     expect(cssString).toContain(
       `.${className}{${removeSpacesAroundCssPropertyValues(style.base)}}`
     );
-    console.log(cssString);
     expect(cssString).toContain(
       `@media (min-width:768px){.${className}{${removeSpacesAroundCssPropertyValues(
         style.responsive["768px"]

--- a/packages/sheet/src/sheet.test.ts
+++ b/packages/sheet/src/sheet.test.ts
@@ -6,6 +6,18 @@ import { theme } from "./theme";
 describe("Sheet class", () => {
   beforeEach(() => {
     sheet.reset();
+    theme.setUserTheme({
+      breakpoints: {
+        "breakpoints.sm": "1000px",
+      },
+      colors: {
+        "colors.primary": "grey",
+        "colors.secondary": "black",
+      },
+      zIndices: {
+        "zIndices.modal": "1000",
+      },
+    });
   });
 
   // // Arrange
@@ -25,6 +37,22 @@ describe("Sheet class", () => {
     ],
   };
 
+  const stylePlaceholders: SystemStyle = {
+    base: "color: t('colors.primary');",
+    responsive: {
+      "t('breakpoints.sm')": "color: t('colors.secondary');",
+    },
+    pseudo: [
+      {
+        key: ":hover",
+        base: "color: t('colors.secondary');",
+        responsive: {
+          "t('breakpoints.sm')": "color: t('colors.primary');",
+        },
+      },
+    ],
+  };
+
   test("addRule() should handle SystemStyle correctly", () => {
     // Act
     const className = sheet.addRule(style);
@@ -34,6 +62,7 @@ describe("Sheet class", () => {
     expect(cssString).toContain(
       `.${className}{${removeSpacesAroundCssPropertyValues(style.base)}}`
     );
+    console.log(cssString);
     expect(cssString).toContain(
       `@media (min-width:768px){.${className}{${removeSpacesAroundCssPropertyValues(
         style.responsive["768px"]
@@ -50,6 +79,14 @@ describe("Sheet class", () => {
     // Act
     const id1 = sheet.addRule(style);
     const id2 = sheet.addRule(style);
+    // Assert
+    expect(id1).toBe(id2);
+  });
+
+  test("addRule() should not add duplicate rules (placeholders)", () => {
+    // Act
+    const id1 = sheet.addRule(stylePlaceholders);
+    const id2 = sheet.addRule(stylePlaceholders);
     // Assert
     expect(id1).toBe(id2);
   });
@@ -82,35 +119,30 @@ describe("Sheet class", () => {
     expect(cssString).toEqual(expectedCSS);
   });
 
-  describe("Sheet placeholders", () => {
-    beforeAll(() => {
-      theme.setUserTheme({
-        breakpoints: {
-          sm: "1000px",
-        },
-        colors: {
-          primary: "red",
-          secondary: "blue",
-        },
-        zIndices: {
-          modal: "1000",
-        },
-      });
-    });
+  test("getCSS() should return the CSS string with unique rules (placeholders)", () => {
+    // Arrange
+    const id = sheet.addRule(stylePlaceholders);
+    // Act
+    const cssString = sheet.getCSS();
+    const expectedCSS = `.${id}{color:grey;}@media (min-width:1000px){.${id}{color:black;}}@media (min-width:1000px){.${id}:hover{color:grey;}}.${id}:hover{color:black;}`;
+    // Assert
+    expect(cssString).toEqual(expectedCSS);
+  });
 
+  describe("Sheet placeholders", () => {
     test("parseCSS() support of t()", () => {
       // Arrange
       const style = `
       color: t("colors.primary");
-      background-color: t('c.secondary');
-      @media (max-width: t("b.sm")) {
+      background-color: t('colors.secondary');
+      @media (max-width: t("breakpoints.sm")) {
         flex-direction: column;
       }
     `;
       // Act
       const className = sheet.parseCSS(style);
       // Assert
-      const expectedCSS = `.${className}{color:red;background-color:blue;}@media (max-width: 1000px){.${className}{flex-direction:column;}}`;
+      const expectedCSS = `.${className}{color:grey;background-color:black;}@media (max-width: 1000px){.${className}{flex-direction:column;}}`;
       expect(sheet.getCSS()).toEqual(expectedCSS);
     });
   });

--- a/packages/sheet/src/sheet.ts
+++ b/packages/sheet/src/sheet.ts
@@ -5,6 +5,7 @@ import {
   removeSpacesExceptInProperties,
 } from "./regex";
 import { compile, serialize, stringify, Element } from "stylis";
+import { applyArrayT, applyT } from "./placeholders";
 
 // to avoid cyclic dependency, we declare an exact same type declared in @kuma-ui/system
 type ResponsiveStyle = {
@@ -34,11 +35,14 @@ export class Sheet {
 
   private css: string[];
 
+  private placeholders: Record<string, string>;
+
   private constructor() {
     this.base = [];
     this.responsive = [];
     this.pseudo = [];
     this.css = [];
+    this.placeholders = theme?.getPlaceholders() || {};
   }
 
   static getInstance() {
@@ -103,6 +107,11 @@ export class Sheet {
    * It's useful for handling complex CSS such as media queries and pseudo selectors.
    */
   parseCSS(style: string): string {
+    const placeholders = theme.getPlaceholders();
+    const scalingFactor = theme.getSpacingScalingFactor();
+
+    style = applyT(style, placeholders, scalingFactor);
+
     const id = Sheet.getClassNamePrefix() + generateHash(style);
 
     const elements: Element[] = [];

--- a/packages/sheet/src/sheet.ts
+++ b/packages/sheet/src/sheet.ts
@@ -35,14 +35,11 @@ export class Sheet {
 
   private css: string[];
 
-  private placeholders: Record<string, string>;
-
   private constructor() {
     this.base = [];
     this.responsive = [];
     this.pseudo = [];
     this.css = [];
-    this.placeholders = theme?.getPlaceholders() || {};
   }
 
   static getInstance() {

--- a/packages/sheet/src/sheet.ts
+++ b/packages/sheet/src/sheet.ts
@@ -105,9 +105,8 @@ export class Sheet {
    */
   parseCSS(style: string): string {
     const placeholders = theme.getPlaceholders();
-    const scalingFactor = theme.getSpacingScalingFactor();
 
-    style = applyT(style, placeholders, scalingFactor);
+    style = applyT(style, placeholders);
 
     const id = Sheet.getClassNamePrefix() + generateHash(style);
 

--- a/packages/sheet/src/sheet.ts
+++ b/packages/sheet/src/sheet.ts
@@ -5,7 +5,7 @@ import {
   removeSpacesExceptInProperties,
 } from "./regex";
 import { compile, serialize, stringify, Element } from "stylis";
-import { applyArrayT, applyT } from "./placeholders";
+import { applyT } from "./placeholders";
 
 // to avoid cyclic dependency, we declare an exact same type declared in @kuma-ui/system
 type ResponsiveStyle = {

--- a/packages/sheet/src/theme.ts
+++ b/packages/sheet/src/theme.ts
@@ -1,3 +1,5 @@
+import { createPlaceholders, Placeholders } from "./placeholders";
+
 export const defaultBreakpoints = Object.freeze({
   sm: "576px",
   md: "768px",
@@ -60,6 +62,7 @@ export class Theme {
     breakpoints:
       globalThis.__KUMA_USER_THEME__?.breakpoints ?? defaultBreakpoints,
   };
+  private _placeholders: Placeholders = {};
 
   private constructor() {}
 
@@ -78,10 +81,19 @@ export class Theme {
       ...this._userTheme,
       ...userTheme,
     };
+    this._placeholders = createPlaceholders(this._userTheme);
   }
 
   getUserTheme() {
     return this._userTheme;
+  }
+
+  getSpacingScalingFactor() {
+    return 8;
+  }
+
+  getPlaceholders(): Placeholders {
+    return this._placeholders;
   }
 
   getVariants(componentName: ComponentName):

--- a/packages/sheet/src/theme.ts
+++ b/packages/sheet/src/theme.ts
@@ -23,18 +23,21 @@ type ComponentName =
   | "Link"
   | "Grid";
 
-export type Tokens =
-  | "colors"
-  | "fonts"
-  | "fontSizes"
-  | "fontWeights"
-  | "lineHeights"
-  | "letterSpacings"
-  | "spacings"
-  | "sizes"
-  | "radii"
-  | "zIndices"
-  | "breakpoints";
+export const tokens = [
+  "colors",
+  "fonts",
+  "fontSizes",
+  "fontWeights",
+  "lineHeights",
+  "letterSpacings",
+  "spacings",
+  "sizes",
+  "radii",
+  "zIndices",
+  "breakpoints",
+] as const;
+
+export type Tokens = (typeof tokens)[number];
 
 export type UserTheme = {
   [K in Tokens]?: Record<string, string> | undefined;
@@ -86,10 +89,6 @@ export class Theme {
 
   getUserTheme() {
     return this._userTheme;
-  }
-
-  getSpacingScalingFactor() {
-    return 8;
   }
 
   getPlaceholders(): Placeholders {


### PR DESCRIPTION
As per https://github.com/kuma-ui/kuma-ui/issues/318 I have added tokens placeholders you can use in css

```
css`
   color: t("color.primary");
   background-color: t("c.primary");
   
  @media (max-width: t("b.sm")) {
     margin-top: t(2);
  }
`
```

Will generate CSS

```
   color: red;
   background-color: red;
   
  @media (max-width: 800px) {
     margin-top: 16px;
  }
```

What is supported
- `t("<token>.<key>")` any token specified in kuma.config.js
- ~`t("c.<key>")` and `t("b.<key>")` shortcuts for colors and breakpoints~
- ~`t(2)` scaling factor like https://mui.com/material-ui/customization/spacing/ . Right now, it is hardcoded as 8px, but it is supper easy to add config to kuma.config~