### PR TITLE
No type error when kuma-style is dynamically given to styled component

### DIFF
--- a/.changeset/styled-component-type-error.md
+++ b/.changeset/styled-component-type-error.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/core": minor
+---
+
+No type error when kuma styles are given directly to Styled components

--- a/packages/core/src/styled.ts
+++ b/packages/core/src/styled.ts
@@ -1,10 +1,5 @@
 import type { ComponentType } from "react";
-import {
-  ResponsiveStyle,
-  StyledProps,
-  StyledKeyType,
-  PseudoProps,
-} from "@kuma-ui/system";
+import { ComponentProps, ComponentWithAs } from "./components/types";
 
 export type StyledComponentProps<T> = T extends keyof JSX.IntrinsicElements
   ? JSX.IntrinsicElements[T]
@@ -17,7 +12,7 @@ export type StyledComponentProps<T> = T extends keyof JSX.IntrinsicElements
 function styled<T extends keyof JSX.IntrinsicElements>(Component: T) {
   const fn = (
     strings: TemplateStringsArray
-  ): React.FC<React.ComponentProps<T>> => {
+  ): ComponentWithAs<T, ComponentProps<"Box">> => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
     throw Error('Using the "styled" tag in runtime is not supported.') as any;
   };


### PR DESCRIPTION
Originally, the following code works.
```ts
const Component = styled("p")`
  color: red;
`;

<Component fontSize={12}>Componentssss</Component>
```
The `font-size:12px` was applied at runtime, but there was a TypeScript type error in the code.

I created a PR in the hope that it may not be a fundamental solution to Styled's dynamic styling, but only to solve errors related to types.