### PR TITLE
fix: improve theme type for theme autocomplete to work

### DIFF
--- a/.changeset/flat-impalas-drum.md
+++ b/.changeset/flat-impalas-drum.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/system": patch
+---
+
+fix: improve theme type for theme autocomplete to work

--- a/packages/system/src/compose.ts
+++ b/packages/system/src/compose.ts
@@ -28,9 +28,9 @@ export type StyledProps<T extends ThemeSystemType = ThemeSystemType> =
     SpaceProps<T> &
     AnimationProps &
     TextProps &
-    LayoutProps &
+    LayoutProps<T> &
     FlexProps<T> &
-    BorderProps &
+    BorderProps<T> &
     OutlineProps &
     PositionProps &
     ShadowProps &


### PR DESCRIPTION
I have improved type autocompletion for Styled Props when configuring the following themes:

- radii
- sizes
- zIndices