### PR TITLE
Add examples of using t() in css, and styled components

### DIFF
--- a/example/vite/kuma.config.ts
+++ b/example/vite/kuma.config.ts
@@ -13,6 +13,9 @@ const theme = createTheme({
     1: "0.25rem",
     4: "1rem",
   },
+  sizes: {
+    sm: "8px",
+  },
   components: {
     Box: {
       baseStyle: {

--- a/website/src/pages/docs/API/css.mdx
+++ b/website/src/pages/docs/API/css.mdx
@@ -46,6 +46,20 @@ export const ThisIsTheCSS = () => {
 
 In this example, the `css` function defines a set of styles, generating a className that we then apply to the div component.
 
+## Using Theme Tokens
+
+You can also utilize [theme tokens](/docs/Theme/ThemeTokens) directly within your `css` function. This allows for a more cohesive and centralized way to manage your design values. Here's how you can use it:
+
+```tsx
+<div
+  className={css`
+    color: t("colors.primary");
+  `}
+/>
+```
+
+In the above example, `t("colors.primary")` fetches the primary color defined in your theme tokens, making it easier to maintain a consistent design across your application.
+
 ## Handling Dynamic Styles
 
 While Kuma UI supports dynamic values for styled props like the one shown below, they are processed at runtime and hence might not be as performance-friendly:

--- a/website/src/pages/docs/API/styled.mdx
+++ b/website/src/pages/docs/API/styled.mdx
@@ -75,3 +75,15 @@ export const ThisIsStyledComponent = styled("div")`
 ```
 
 In the above example, the `flex-direction` changes to `column` when the viewport width falls below the 'sm' breakpoint value defined in the configuration. Thus, you can leverage the power of these shared media query breakpoints to write more maintainable and consistent media queries in your styles.
+
+## Using Theme Tokens
+
+You can also utilize [theme tokens](/docs/Theme/ThemeTokens) directly within your `styled` function. This allows for a more cohesive and centralized way to manage your design values. Here's how you can use it:
+
+```tsx
+export const ColorComponent = styled("div")`
+  color: t("colors.primary");
+`;
+```
+
+In the above example, `t("colors.primary")` fetches the primary color defined in your theme tokens, making it easier to maintain a consistent design across your application.

--- a/website/src/pages/docs/Theme/ThemeTokens.mdx
+++ b/website/src/pages/docs/Theme/ThemeTokens.mdx
@@ -150,3 +150,39 @@ const theme = createTheme({
   },
 });
 ```
+
+## Usage
+
+Here are some examples of how you can use theme tokens in different contexts:
+
+### In Components
+
+You can use theme tokens directly in your components to apply styles:
+
+```tsx
+<Box color={"colors.primary"} />
+```
+
+### In Styled Components
+
+Similarly, you can use theme tokens within styled components to maintain a consistent design:
+
+```tsx
+const ColorComponent = styled.div`
+  color: t("colors.primary");
+`;
+```
+
+### In CSS
+
+You can also use theme tokens within the css function to apply styles dynamically:
+
+```tsx
+<div
+  className={css`
+    color: t("colors.primary");
+  `}
+/>
+```
+
+By utilizing theme tokens in these ways, you can ensure a cohesive and consistent design language across your application.


### PR DESCRIPTION
In this PR, I have added examples demonstrating how to use `t()` in `css`, and `styled components`. This is implemented in the recent PR #327 