### PR TITLE
Implement ForwardRef in Components

### DIFF
--- a/.changeset/clean-wombats-destroy.md
+++ b/.changeset/clean-wombats-destroy.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/core": minor
+---
+
+Implement ForwardRef in Components

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+example/*

--- a/example/vite/src/App.tsx
+++ b/example/vite/src/App.tsx
@@ -1,13 +1,37 @@
-import { Box, HStack, styled, css, Select as S, Text } from "@kuma-ui/core";
+import {
+  Box,
+  HStack,
+  styled,
+  css,
+  Select as S,
+  Text,
+  Button,
+} from "@kuma-ui/core";
 import { Dynamic } from "./Dynamic";
+import { useEffect, useRef } from "react";
 
 function App() {
-  const red = "red";
+  const ref = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (ref.current) {
+      console.log("ref", ref.current);
+      console.log("buttonRef", buttonRef.current);
+    }
+  }, []);
+
   return (
     <HStack flexDir={["row", "column"]} gap="spacings.4">
       <Text>hello</Text>
       <Dynamic key={1} />
       <Dynamic key={2} />
+      <Box ref={ref} color={true ? "red" : "blue"}>
+        hello
+      </Box>
+      <Button ref={buttonRef} color={true ? "red" : "blue"}>
+        hello
+      </Button>
     </HStack>
   );
 }

--- a/packages/core/src/components/Box/react/DynamicBox.tsx
+++ b/packages/core/src/components/Box/react/DynamicBox.tsx
@@ -9,55 +9,56 @@ import {
 } from "../../../registry/StyleRegistry";
 import { extractDynamicProps, getCachedStyle } from "./utils";
 import { theme } from "@kuma-ui/sheet";
+import { forwardRef } from "../../forwardRef";
 
 const defaultRegistry = createStyleRegistry();
 const useInsertionEffect = React.useInsertionEffect || React.useLayoutEffect;
 
-export const DynamicBox: BoxComponent = ({
-  as: Component = "div",
-  children,
-  variant,
-  IS_KUMA_DEFAULT,
-  ...props
-}) => {
-  const registry = useStyleRegistry() || defaultRegistry;
+export const DynamicBox: BoxComponent = forwardRef(
+  (
+    { as: Component = "div", children, variant, IS_KUMA_DEFAULT, ...props },
+    ref
+  ) => {
+    const registry = useStyleRegistry() || defaultRegistry;
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
-  const variantStyle: object = (() => {
-    if (!variant) return {};
-    // eslint-disable-next-line no-extra-boolean-cast -- FIXME
-    if (!!IS_KUMA_DEFAULT) return {};
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- FIXME
-    return theme.getVariants("Box")?.variants?.[variant];
-  })();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+    const variantStyle: object = (() => {
+      if (!variant) return {};
+      // eslint-disable-next-line no-extra-boolean-cast -- FIXME
+      if (!!IS_KUMA_DEFAULT) return {};
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- FIXME
+      return theme.getVariants("Box")?.variants?.[variant];
+    })();
 
-  const { dynamicProps, restProps } = extractDynamicProps({
-    ...variantStyle,
-    ...props,
-  });
+    const { dynamicProps, restProps } = extractDynamicProps({
+      ...variantStyle,
+      ...props,
+    });
 
-  const { className, css } = getCachedStyle(dynamicProps);
+    const { className, css } = getCachedStyle(dynamicProps);
 
-  const box = React.createElement(
-    Component,
-    {
-      ...restProps,
-      className: [restProps.className, className].filter(Boolean).join(" "),
-    },
-    children
-  );
+    const box = React.createElement(
+      Component,
+      {
+        ref,
+        ...restProps,
+        className: [restProps.className, className].filter(Boolean).join(" "),
+      },
+      children
+    );
 
-  if (!isBrowser) {
-    registry.add(className, css);
+    if (!isBrowser) {
+      registry.add(className, css);
+      return box;
+    }
+
+    useInsertionEffect(() => {
+      registry.add(className, css);
+      return () => {
+        registry.remove(className);
+      };
+    }, [className, css]);
+
     return box;
   }
-
-  useInsertionEffect(() => {
-    registry.add(className, css);
-    return () => {
-      registry.remove(className);
-    };
-  }, [className, css]);
-
-  return box;
-};
+);

--- a/packages/core/src/components/Box/react/StaticBox.tsx
+++ b/packages/core/src/components/Box/react/StaticBox.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import type { BoxComponent } from "./types";
+import { forwardRef } from "../../forwardRef";
 
-export const StaticBox: BoxComponent = ({
-  as: Component = "div",
-  children,
-  IS_KUMA_DEFAULT,
-  ...props
-}) => React.createElement(Component, props, children);
+export const StaticBox: BoxComponent = forwardRef(
+  ({ as: Component = "div", children, IS_KUMA_DEFAULT, ...props }, ref) =>
+    React.createElement(Component, { ref, ...props }, children)
+);

--- a/packages/core/src/components/Box/react/index.tsx
+++ b/packages/core/src/components/Box/react/index.tsx
@@ -3,6 +3,7 @@ import type { BoxComponent, BoxProps } from "./types";
 import { DynamicBox } from "./DynamicBox";
 import { StaticBox } from "./StaticBox";
 import { hasDynamicProps } from "./utils";
+import { forwardRef } from "../../forwardRef";
 
 /**
  * Box is the most abstract component in Kuma UI, providing a base upon which all other components are built.
@@ -10,12 +11,11 @@ import { hasDynamicProps } from "./utils";
  *
  * @see — http://kuma-ui.com/docs/Components/Box
  */
-const Box: BoxComponent = ({ children, ...props }) => {
+const Box: BoxComponent = forwardRef(({ children, ...props }, ref) => {
   if (hasDynamicProps(props)) {
-    return React.createElement(DynamicBox, props, children);
+    return React.createElement(DynamicBox, { ref, ...props }, children);
   }
 
-  return React.createElement(StaticBox, props, children);
-};
-
+  return React.createElement(StaticBox, { ref, ...props }, children);
+});
 export { Box, type BoxComponent, BoxProps };

--- a/packages/core/src/components/Button/react.tsx
+++ b/packages/core/src/components/Button/react.tsx
@@ -10,6 +10,7 @@ import {
 import { Box } from "../Box";
 import { theme } from "@kuma-ui/sheet";
 import { defaultButtonTag } from "./handler";
+import { forwardRef } from "../forwardRef";
 
 type ButtonProps = ComponentProps<"Button">;
 
@@ -20,24 +21,23 @@ type ButtonComponent<T extends As = "button"> = ComponentWithAs<T, ButtonProps>;
  *
  * @see — http://kuma-ui.com/docs/Components/Button
  */
-const Button: ButtonComponent = <T extends As = "button">({
-  as: Component = defaultButtonTag,
-  children,
-  ...props
-}: MergeWithAs<PropsOf<T>, ButtonProps>) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
-  const variant = props.variant
-    ? theme.getVariants("Button")?.variants?.[props.variant]
-    : {};
-  return (
-    <Box
-      as={Component}
-      {...variant}
-      {...props}
-      children={children}
-      IS_KUMA_DEFAULT
-    />
-  );
-};
+const Button: ButtonComponent = forwardRef(
+  ({ as: Component = defaultButtonTag, children, ...props }, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+    const variant = props.variant
+      ? theme.getVariants("Button")?.variants?.[props.variant]
+      : {};
+    return (
+      <Box
+        as={Component}
+        ref={ref}
+        {...variant}
+        {...props}
+        children={children}
+        IS_KUMA_DEFAULT
+      />
+    );
+  }
+);
 
 export { Button, type ButtonComponent, ButtonProps };

--- a/packages/core/src/components/Flex/react.tsx
+++ b/packages/core/src/components/Flex/react.tsx
@@ -10,6 +10,7 @@ import {
 } from "../types";
 import { Box } from "../Box";
 import { defaultFlexTag } from "./handler";
+import { forwardRef } from "../forwardRef";
 
 type FlexProps = ComponentProps<"Flex">;
 
@@ -21,24 +22,23 @@ type FlexComponent<T extends As = "div"> = ComponentWithAs<T, FlexProps>;
  *
  * @see — http://kuma-ui.com/docs/Components/Flex
  */
-const Flex: FlexComponent = <T extends As = "div">({
-  as: Component = defaultFlexTag,
-  children,
-  ...props
-}: MergeWithAs<PropsOf<T>, FlexProps>) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
-  const variant = props.variant
-    ? theme.getVariants("Flex")?.variants?.[props.variant]
-    : {};
-  return (
-    <Box
-      as={Component}
-      {...variant}
-      {...props}
-      children={children}
-      IS_KUMA_DEFAULT
-    />
-  );
-};
+const Flex: FlexComponent = forwardRef(
+  ({ as: Component = defaultFlexTag, children, ...props }, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+    const variant = props.variant
+      ? theme.getVariants("Flex")?.variants?.[props.variant]
+      : {};
+    return (
+      <Box
+        as={Component}
+        ref={ref}
+        {...variant}
+        {...props}
+        children={children}
+        IS_KUMA_DEFAULT
+      />
+    );
+  }
+);
 
 export { Flex, type FlexComponent, FlexProps };

--- a/packages/core/src/components/Grid/react.tsx
+++ b/packages/core/src/components/Grid/react.tsx
@@ -9,6 +9,7 @@ import {
 } from "../types";
 import { Box } from "../Box";
 import { defaultGridTag } from "./handler";
+import { forwardRef } from "../forwardRef";
 
 type GridProps = ComponentProps<"Grid">;
 
@@ -19,24 +20,23 @@ type GridComponent<T extends As = "div"> = ComponentWithAs<T, GridProps>;
  *
  * @see — http://kuma-ui.com/docs/Components/Grid
  */
-const Grid: GridComponent = <T extends As = "div">({
-  as: Component = defaultGridTag,
-  children,
-  ...props
-}: MergeWithAs<PropsOf<T>, GridProps>) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
-  const variant = props.variant
-    ? theme.getVariants("Grid")?.variants?.[props.variant]
-    : {};
-  return (
-    <Box
-      as={Component}
-      {...variant}
-      {...props}
-      children={children}
-      IS_KUMA_DEFAULT
-    />
-  );
-};
+const Grid: GridComponent = forwardRef(
+  ({ as: Component = defaultGridTag, children, ...props }, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+    const variant = props.variant
+      ? theme.getVariants("Grid")?.variants?.[props.variant]
+      : {};
+    return (
+      <Box
+        as={Component}
+        ref={ref}
+        {...variant}
+        {...props}
+        children={children}
+        IS_KUMA_DEFAULT
+      />
+    );
+  }
+);
 
 export { Grid, type GridComponent, GridProps };

--- a/packages/core/src/components/HStack/react.tsx
+++ b/packages/core/src/components/HStack/react.tsx
@@ -10,6 +10,7 @@ import {
 } from "../types";
 import { Box } from "../Box";
 import { defaultHStackTag } from "./handler";
+import { forwardRef } from "../forwardRef";
 
 type HStackProps = ComponentProps<"HStack">;
 
@@ -20,24 +21,23 @@ type HStackComponent<T extends As = "div"> = ComponentWithAs<T, HStackProps>;
  *
  * @see — http://kuma-ui.com/docs/Components/HStack
  */
-const HStack: HStackComponent = <T extends As = "div">({
-  as: Component = defaultHStackTag,
-  children,
-  ...props
-}: MergeWithAs<PropsOf<T>, HStackProps>) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
-  const variant = props.variant
-    ? theme.getVariants("HStack")?.variants?.[props.variant]
-    : {};
-  return (
-    <Box
-      as={Component}
-      {...variant}
-      {...props}
-      children={children}
-      IS_KUMA_DEFAULT
-    />
-  );
-};
+const HStack: HStackComponent = forwardRef(
+  ({ as: Component = defaultHStackTag, children, ...props }, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+    const variant = props.variant
+      ? theme.getVariants("HStack")?.variants?.[props.variant]
+      : {};
+    return (
+      <Box
+        as={Component}
+        ref={ref}
+        {...variant}
+        {...props}
+        children={children}
+        IS_KUMA_DEFAULT
+      />
+    );
+  }
+);
 
 export { HStack, type HStackComponent, HStackProps };

--- a/packages/core/src/components/Heading/handler.ts
+++ b/packages/core/src/components/Heading/handler.ts
@@ -1,6 +1,6 @@
 import { StyledProps } from "@kuma-ui/system";
 
-export const defaultHeadingTag = "div";
+export const defaultHeadingTag = "h1";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type HeadingSpecificProps = {};

--- a/packages/core/src/components/Heading/react.tsx
+++ b/packages/core/src/components/Heading/react.tsx
@@ -10,6 +10,7 @@ import {
 import { Box } from "../Box";
 import { theme } from "@kuma-ui/sheet";
 import { defaultHeadingTag } from "./handler";
+import { forwardRef } from "../forwardRef";
 
 type HeadingProps = ComponentProps<"Heading">;
 
@@ -23,27 +24,24 @@ type HeadingComponent<
  *
  * @see — http://kuma-ui.com/docs/Components/Heading
  */
-const Heading: HeadingComponent = <
-  T extends "h1" | "h2" | "h3" | "h4" | "h5" | "h6" = "h1"
->({
-  as: Component = defaultHeadingTag,
-  children,
-  ...props
-}: MergeWithAs<PropsOf<T>, HeadingProps>) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
-  const variant = props.variant
-    ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any -- FIXME
-      theme.getVariants("Heading")?.variants?.[props.variant as any]
-    : {};
-  return (
-    <Box
-      as={Component}
-      {...variant}
-      {...props}
-      children={children}
-      IS_KUMA_DEFAULT
-    />
-  );
-};
+const Heading: HeadingComponent = forwardRef(
+  ({ as: Component = defaultHeadingTag, children, ...props }, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+    const variant = props.variant
+      ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any -- FIXME
+        theme.getVariants("Heading")?.variants?.[props.variant as any]
+      : {};
+    return (
+      <Box
+        as={Component}
+        ref={ref}
+        {...variant}
+        {...props}
+        children={children}
+        IS_KUMA_DEFAULT
+      />
+    );
+  }
+);
 
 export { Heading, type HeadingComponent, HeadingProps };

--- a/packages/core/src/components/Image/react.tsx
+++ b/packages/core/src/components/Image/react.tsx
@@ -10,6 +10,7 @@ import {
 import { Box } from "../Box";
 import { theme } from "@kuma-ui/sheet";
 import { defaultImageTag } from "./handler";
+import { forwardRef } from "../forwardRef";
 
 type ImageProps = ComponentProps<"Image">;
 
@@ -20,25 +21,24 @@ type ImageComponent<T extends As = "img"> = ComponentWithAs<T, ImageProps>;
  *
  * @see — http://kuma-ui.com/docs/Components/Image
  */
-const Image: ImageComponent = <T extends As>({
-  as: Component = defaultImageTag,
-  children,
-  ...props
-}: MergeWithAs<PropsOf<T>, ImageProps>) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
-  const variant = props.variant
-    ? theme.getVariants("Image")?.variants?.[props.variant]
-    : {};
+const Image: ImageComponent = forwardRef(
+  ({ as: Component = defaultImageTag, children, ...props }, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+    const variant = props.variant
+      ? theme.getVariants("Image")?.variants?.[props.variant]
+      : {};
 
-  return (
-    <Box
-      as={Component}
-      {...variant}
-      {...props}
-      children={children}
-      IS_KUMA_DEFAULT
-    />
-  );
-};
+    return (
+      <Box
+        as={Component}
+        ref={ref}
+        {...variant}
+        {...props}
+        children={children}
+        IS_KUMA_DEFAULT
+      />
+    );
+  }
+);
 
 export { Image, type ImageComponent, ImageProps };

--- a/packages/core/src/components/Input/react.tsx
+++ b/packages/core/src/components/Input/react.tsx
@@ -5,6 +5,7 @@ import { Box } from "../Box";
 import { theme } from "@kuma-ui/sheet";
 import { ComponentProps } from "../types";
 import { defaultInputTag } from "./handler";
+import { forwardRef } from "../forwardRef";
 
 type InputProps = ComponentProps<"Input">;
 type InputComponent<T extends As = "input"> = ComponentWithAs<T, InputProps>;
@@ -14,24 +15,23 @@ type InputComponent<T extends As = "input"> = ComponentWithAs<T, InputProps>;
  *
  * @see — http://kuma-ui.com/docs/Components/Input
  */
-const Input: InputComponent = <T extends As>({
-  as: Component = defaultInputTag,
-  children,
-  ...props
-}: MergeWithAs<PropsOf<T>, InputProps>) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
-  const variantStyle = props.variant
-    ? theme.getVariants("Input")?.variants?.[props.variant]
-    : {};
-  return (
-    <Box
-      as={Component}
-      {...variantStyle}
-      {...props}
-      children={children}
-      IS_KUMA_DEFAULT
-    />
-  );
-};
+const Input: InputComponent = forwardRef(
+  ({ as: Component = defaultInputTag, children, ...props }, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+    const variantStyle = props.variant
+      ? theme.getVariants("Input")?.variants?.[props.variant]
+      : {};
+    return (
+      <Box
+        as={Component}
+        ref={ref}
+        {...variantStyle}
+        {...props}
+        children={children}
+        IS_KUMA_DEFAULT
+      />
+    );
+  }
+);
 
 export { Input, type InputComponent, InputProps };

--- a/packages/core/src/components/Link/react.tsx
+++ b/packages/core/src/components/Link/react.tsx
@@ -10,6 +10,7 @@ import {
 import { Box } from "../Box";
 import { theme } from "@kuma-ui/sheet";
 import { defaultLinkTag } from "./handler";
+import { forwardRef } from "../forwardRef";
 
 type LinkProps = ComponentProps<"Link">;
 
@@ -20,25 +21,24 @@ type LinkComponent<T extends As = "a"> = ComponentWithAs<T, LinkProps>;
  *
  * @see — http://kuma-ui.com/docs/Components/Link
  */
-const Link: LinkComponent = <T extends As = "a">({
-  as: Component = defaultLinkTag,
-  children,
-  ...props
-}: MergeWithAs<PropsOf<T>, LinkProps>) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
-  const variant = props.variant
-    ? theme.getVariants("Link")?.variants?.[props.variant]
-    : {};
+const Link: LinkComponent = forwardRef(
+  ({ as: Component = defaultLinkTag, children, ...props }, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+    const variant = props.variant
+      ? theme.getVariants("Link")?.variants?.[props.variant]
+      : {};
 
-  return (
-    <Box
-      as={Component}
-      {...variant}
-      {...props}
-      children={children}
-      IS_KUMA_DEFAULT
-    />
-  );
-};
+    return (
+      <Box
+        as={Component}
+        ref={ref}
+        {...variant}
+        {...props}
+        children={children}
+        IS_KUMA_DEFAULT
+      />
+    );
+  }
+);
 
 export { Link, type LinkComponent, LinkProps };

--- a/packages/core/src/components/Select/react.tsx
+++ b/packages/core/src/components/Select/react.tsx
@@ -10,6 +10,7 @@ import {
 import { Box } from "../Box";
 import { theme } from "@kuma-ui/sheet";
 import { defaultSelectTag } from "./handler";
+import { forwardRef } from "../forwardRef";
 
 type SelectProps = ComponentProps<"Select">;
 
@@ -20,25 +21,24 @@ type SelectComponent<T extends As = "select"> = ComponentWithAs<T, SelectProps>;
  *
  * @see — http://kuma-ui.com/docs/Components/Select
  */
-const Select: SelectComponent = <T extends As = "select">({
-  as: Component = defaultSelectTag,
-  children,
-  ...props
-}: MergeWithAs<PropsOf<T>, SelectProps>) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
-  const variantStyle = props.variant
-    ? theme.getVariants("Select")?.variants?.[props.variant]
-    : {};
+const Select: SelectComponent = forwardRef(
+  ({ as: Component = defaultSelectTag, children, ...props }, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+    const variantStyle = props.variant
+      ? theme.getVariants("Select")?.variants?.[props.variant]
+      : {};
 
-  return (
-    <Box
-      as={Component}
-      {...variantStyle}
-      {...props}
-      children={children}
-      IS_KUMA_DEFAULT
-    />
-  );
-};
+    return (
+      <Box
+        as={Component}
+        ref={ref}
+        {...variantStyle}
+        {...props}
+        children={children}
+        IS_KUMA_DEFAULT
+      />
+    );
+  }
+);
 
 export { Select, type SelectComponent, SelectProps };

--- a/packages/core/src/components/Spacer/react.tsx
+++ b/packages/core/src/components/Spacer/react.tsx
@@ -11,6 +11,7 @@ import { Box } from "../Box";
 import { SpacerSpecificProps, spacerHandler } from "./handler";
 import { theme } from "@kuma-ui/sheet";
 import { defaultSpacerTag } from "./handler";
+import { forwardRef } from "../forwardRef";
 
 type SpacerProps = ComponentProps<"Spacer"> & SpacerSpecificProps;
 
@@ -22,32 +23,32 @@ type SpacerComponent<T extends As = "div"> = ComponentWithAs<T, SpacerProps>;
  *
  * @see — Further documentation will be available in the future.
  */
-const Spacer: SpacerComponent = <T extends As = "div">({
-  as: Component = defaultSpacerTag,
-  children,
-  size,
-  horizontal,
-  ...props
-}: MergeWithAs<PropsOf<T>, SpacerProps>) => {
-  props = {
-    ...spacerHandler({ size, horizontal }),
-    ...props,
-  };
+const Spacer: SpacerComponent = forwardRef(
+  (
+    { as: Component = defaultSpacerTag, children, size, horizontal, ...props },
+    ref
+  ) => {
+    props = {
+      ...spacerHandler({ size, horizontal }),
+      ...props,
+    };
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
-  const variant = props.variant
-    ? theme.getVariants("Spacer")?.variants?.[props.variant]
-    : {};
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+    const variant = props.variant
+      ? theme.getVariants("Spacer")?.variants?.[props.variant]
+      : {};
 
-  return (
-    <Box
-      as={Component}
-      {...variant}
-      {...props}
-      children={children}
-      IS_KUMA_DEFAULT
-    />
-  );
-};
+    return (
+      <Box
+        as={Component}
+        ref={ref}
+        {...variant}
+        {...props}
+        children={children}
+        IS_KUMA_DEFAULT
+      />
+    );
+  }
+);
 
 export { Spacer, type SpacerComponent, SpacerProps };

--- a/packages/core/src/components/Text/react.tsx
+++ b/packages/core/src/components/Text/react.tsx
@@ -10,6 +10,7 @@ import {
 import { Box } from "../Box";
 import { theme } from "@kuma-ui/sheet";
 import { defaultTextTag } from "./handler";
+import { forwardRef } from "../forwardRef";
 
 type TextProps = ComponentProps<"Text">;
 
@@ -20,25 +21,24 @@ type TextComponent<T extends As = "p"> = ComponentWithAs<T, TextProps>;
  *
  * @see — http://kuma-ui.com/docs/Components/Text
  */
-const Text: TextComponent = <T extends As = "p">({
-  as: Component = defaultTextTag,
-  children,
-  ...props
-}: MergeWithAs<PropsOf<T>, TextProps>) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
-  const variant = props.variant
-    ? theme.getVariants("Text")?.variants?.[props.variant]
-    : {};
+const Text: TextComponent = forwardRef(
+  ({ as: Component = defaultTextTag, children, ...props }, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+    const variant = props.variant
+      ? theme.getVariants("Text")?.variants?.[props.variant]
+      : {};
 
-  return (
-    <Box
-      as={Component}
-      {...variant}
-      {...props}
-      children={children}
-      IS_KUMA_DEFAULT
-    />
-  );
-};
+    return (
+      <Box
+        as={Component}
+        ref={ref}
+        {...variant}
+        {...props}
+        children={children}
+        IS_KUMA_DEFAULT
+      />
+    );
+  }
+);
 
 export { Text, type TextComponent, TextProps };

--- a/packages/core/src/components/VStack/react.tsx
+++ b/packages/core/src/components/VStack/react.tsx
@@ -10,6 +10,7 @@ import {
 } from "../types";
 import { Box } from "../Box";
 import { defaultVStackTag } from "./handler";
+import { forwardRef } from "../forwardRef";
 
 type VStackProps = ComponentProps<"VStack">;
 
@@ -20,24 +21,23 @@ type VStackComponent<T extends As = "div"> = ComponentWithAs<T, VStackProps>;
  *
  * @see — http://kuma-ui.com/docs/Components/VStack
  */
-const VStack: VStackComponent = <T extends As = "div">({
-  as: Component = defaultVStackTag,
-  children,
-  ...props
-}: MergeWithAs<PropsOf<T>, VStackProps>) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
-  const variant = props.variant
-    ? theme.getVariants("VStack")?.variants?.[props.variant]
-    : {};
-  return (
-    <Box
-      as={Component}
-      {...variant}
-      {...props}
-      children={children}
-      IS_KUMA_DEFAULT
-    />
-  );
-};
+const VStack: VStackComponent = forwardRef(
+  ({ as: Component = defaultVStackTag, children, ...props }, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+    const variant = props.variant
+      ? theme.getVariants("VStack")?.variants?.[props.variant]
+      : {};
+    return (
+      <Box
+        as={Component}
+        ref={ref}
+        {...variant}
+        {...props}
+        children={children}
+        IS_KUMA_DEFAULT
+      />
+    );
+  }
+);
 
 export { VStack, type VStackComponent, VStackProps };

--- a/packages/core/src/components/forwardRef.ts
+++ b/packages/core/src/components/forwardRef.ts
@@ -1,0 +1,44 @@
+/**
+ * This code is based on the implementation from Chakra UI, an open-source UI library.
+ * The original implementation can be found at:
+ * https://github.com/chakra-ui/chakra-ui/blob/main/packages/core/system/src/forward-ref.tsx
+ *
+ * MIT License
+ * Copyright (c) 2019 Segun Adebayo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { forwardRef as forwardReactRef } from "react";
+import { PropsOf, RightJoinProps, ComponentWithAs, As } from "./types";
+
+export function forwardRef<Props extends object, Component extends As>(
+  component: React.ForwardRefRenderFunction<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any,
+    RightJoinProps<PropsOf<Component>, Props> & {
+      as?: As;
+    }
+  >
+): ComponentWithAs<Component, Props> {
+  return forwardReactRef(component) as unknown as ComponentWithAs<
+    Component,
+    Props
+  >;
+}

--- a/packages/core/src/components/types.ts
+++ b/packages/core/src/components/types.ts
@@ -42,7 +42,7 @@ export type MergeWithAs<
     as?: AsComponent;
   };
 
-type RightJoinProps<
+export type RightJoinProps<
   SourceProps extends object = {},
   OverrideProps extends object = {}
 > = OmitCommonProps<SourceProps, keyof OverrideProps> & OverrideProps;

--- a/packages/core/src/tests/vitest.setup.ts
+++ b/packages/core/src/tests/vitest.setup.ts
@@ -1,7 +1,7 @@
 import type { TestingLibraryMatchers } from "@testing-library/jest-dom/matchers";
 import matchers from "@testing-library/jest-dom/matchers";
 import { cleanup } from "@testing-library/react";
-import { beforeEach, expect } from "vitest";
+import { beforeEach, expect, vi } from "vitest";
 
 declare module "vitest" {
   interface Assertion<T>
@@ -12,5 +12,6 @@ declare module "vitest" {
 expect.extend(matchers);
 
 beforeEach(() => {
+  vi.clearAllMocks();
   cleanup();
 });


### PR DESCRIPTION
Fix #256 
This PR introduces the use of `forwardRef` in our components.

## Attribution
The `forwardRef` implementation is based on Chakra UI's solution found at:
[Chakra UI forwardRef Implementation](https://github.com/chakra-ui/chakra-ui/blob/main/packages/core/system/src/forward-ref.tsx)
