### PR TITLE
Override original prop types with `as` component props

### DIFF
--- a/.changeset/ten-pens-smile.md
+++ b/.changeset/ten-pens-smile.md
@@ -2,4 +2,4 @@
 "@kuma-ui/core": patch
 ---
 
-Override original props with as component props
+Override original prop types with `as` component props

--- a/.changeset/ten-pens-smile.md
+++ b/.changeset/ten-pens-smile.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/core": patch
+---
+
+Override original props with as component props

--- a/example/vite/src/App.tsx
+++ b/example/vite/src/App.tsx
@@ -8,11 +8,16 @@ import {
   Button,
 } from "@kuma-ui/core";
 import { Dynamic } from "./Dynamic";
-import { useEffect, useRef } from "react";
+import { MouseEventHandler, useEffect, useRef } from "react";
 
 function App() {
   const ref = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const buttonRef2 = useRef<HTMLButtonElement>(null);
+
+  const onClick: MouseEventHandler<HTMLButtonElement> = () => {
+    alert("Hi");
+  };
 
   useEffect(() => {
     if (ref.current) {
@@ -32,6 +37,9 @@ function App() {
       <Button ref={buttonRef} color={true ? "red" : "blue"}>
         hello
       </Button>
+      <Box as="button" ref={buttonRef2} onClick={onClick}>
+        Click Me!
+      </Box>
     </HStack>
   );
 }

--- a/packages/core/src/components/Box/react/box.test.tsx
+++ b/packages/core/src/components/Box/react/box.test.tsx
@@ -1,7 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, expectTypeOf } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { Box } from ".";
-import React from "react";
+import React, { ComponentProps, MouseEventHandler, createRef } from "react";
 
 describe("Box component", () => {
   it("should render correctly with given static props", () => {
@@ -16,5 +16,14 @@ describe("Box component", () => {
       padding: "8px",
       color: "rgb(255, 255, 255)",
     });
+  });
+
+  it("should correctly override prop types by `as` prop", () => {
+    // Arrange
+    const ref = createRef<HTMLButtonElement>();
+    const onClick: MouseEventHandler<HTMLButtonElement> = () => {};
+
+    // Assert
+    <Box as="button" ref={ref} onClick={onClick} />;
   });
 });

--- a/packages/core/src/components/types.ts
+++ b/packages/core/src/components/types.ts
@@ -37,10 +37,12 @@ export type MergeWithAs<
   AsProps extends object,
   AdditionalProps extends object = {},
   AsComponent extends As = As,
-> = RightJoinProps<ComponentProps, AdditionalProps> &
+> = RightJoinProps<
+  RightJoinProps<ComponentProps, AdditionalProps>,
   RightJoinProps<AsProps, AdditionalProps> & {
     as?: AsComponent;
-  };
+  }
+>;
 
 export type RightJoinProps<
   SourceProps extends object = {},


### PR DESCRIPTION
Fix https://github.com/kuma-ui/kuma-ui/pull/343#pullrequestreview-1651872055