### PR TITLE
Fix generator to work custom style in pseudo css correctly

### DIFF
--- a/.changeset/chatty-berries-raise.md
+++ b/.changeset/chatty-berries-raise.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/system": patch
+---
+
+Apply custom theme in pseudo elements

--- a/example/next-app-router/src/app/page.tsx
+++ b/example/next-app-router/src/app/page.tsx
@@ -42,6 +42,13 @@ export default function Home() {
       <StyledFn>styled fn</StyledFn>
       <StyledProperty>styled property</StyledProperty>
       <StyledExtended>styled extended</StyledExtended>
+      <k.button _hover={{
+        bgColor: "colors.blue"
+      }}
+      _active={{
+        bgColor: "colors.red.100"
+      }}
+      >psuedo button</k.button>
     </div>
   );
 }

--- a/packages/system/src/generator.ts
+++ b/packages/system/src/generator.ts
@@ -20,25 +20,45 @@ export class StyleGenerator {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
     const pseudoProps: { [key: string]: any } = {};
 
+    const findCustomStyle = (value: string) => {
+      const userTheme = theme.getUserTheme();
+      const propKey = value.split(".")[0] as Tokens;
+      if(userTheme[propKey] === undefined) return undefined;
+
+      for (const key in userTheme[propKey]) {
+        if (value === key) {
+          return userTheme[propKey]![key];
+        }
+      }
+      return undefined;
+    }
+    
     for (const [propName, propValue] of Object.entries(props)) {
       if (
         typeof propValue === "string" &&
         /[a-zA-Z]+\.[a-zA-Z0-9]+/.test(propValue)
       ) {
-        const userTheme = theme.getUserTheme();
-        const propKey = propValue.split(".")[0] as Tokens;
-        if (userTheme[propKey] !== undefined) {
-          for (const key in userTheme[propKey]) {
-            if (propValue === key) {
-              styledProps[propName] = userTheme[propKey]![key];
-              break;
-            }
+          const customStyle = findCustomStyle(propValue);
+          if(customStyle !== undefined) {
+            styledProps[propName] = customStyle;
           }
-        }
       } else if (isStyledProp(propName)) {
         styledProps[propName] = propValue;
       } else if (isPseudoProps(propName)) {
         pseudoProps[propName] = propValue;
+        for(const [name, value] of Object.entries(propValue)) {
+          if (
+            typeof value === "string" &&
+            /[a-zA-Z]+\.[a-zA-Z0-9]+/.test(value)
+          ) {
+              const customStyle = findCustomStyle(value);
+              if(customStyle !== undefined) {
+                pseudoProps[propName] = {
+                  [name]: customStyle
+                }
+              }
+            }
+        }
       }
     }
 


### PR DESCRIPTION
This is for https://github.com/kuma-ui/kuma-ui/issues/349.

Mapping of custom styles in pseudo-elements when generating styles was not correct.
I couldn't setting custom style in test code in `src/system/generator.test.ts`, so I added `k.button` element in the next.js example as a test.