### PR TITLE
Enable `forwardRef` Usage in Components Created through the `styled` API

### DIFF
--- a/.changeset/hot-insects-poke.md
+++ b/.changeset/hot-insects-poke.md
@@ -1,0 +1,6 @@
+---
+"@kuma-ui/babel-plugin": patch
+"@kuma-ui/compiler": patch
+---
+
+Enable forwardRef Usage in Components Created through the styled API

--- a/example/next-app-router/package.json
+++ b/example/next-app-router/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port 2999",
     "build": "next build",
     "export": "next build && next export",
     "start": "next start",

--- a/example/vite/src/App.tsx
+++ b/example/vite/src/App.tsx
@@ -22,7 +22,7 @@ function App() {
   useEffect(() => {
     if (ref.current) {
       console.log("ref", ref.current);
-      console.log("buttonRef", buttonRef.current);
+      // console.log("buttonRef", buttonRef.current);
     }
   }, []);
 
@@ -31,17 +31,22 @@ function App() {
       <Text>hello</Text>
       <Dynamic key={1} />
       <Dynamic key={2} />
-      <Box ref={ref} color={true ? "red" : "blue"}>
+      {/* <Box ref={ref} color={true ? "red" : "blue"}>
         hello
-      </Box>
+      </Box> */}
       <Button ref={buttonRef} color={true ? "red" : "blue"}>
         hello
       </Button>
       <Box as="button" ref={buttonRef2} onClick={onClick}>
         Click Me!
       </Box>
+      <Styled ref={ref}>hello</Styled>
     </HStack>
   );
 }
 
 export default App;
+
+const Styled = styled.div`
+  color: orange;
+`;

--- a/packages/babel-plugin/src/__test__/__snapshots__/component.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/component.test.ts.snap
@@ -5,7 +5,7 @@ exports[`headless component > using default props should match snapshot 1`] = `
 .🐻-1587700805 { color: green;text-decoration: line-through;font-size: 16px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { Text } from '@kuma-ui/core';
 function App() {
   return <p className={\\"🐻-1587700805\\"} />;
@@ -18,7 +18,7 @@ exports[`headless component > using default props with inline props should match
 .🐻-4138457428 { color: blue;text-decoration: line-through;font-size: 12px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { Text } from '@kuma-ui/core';
 function App() {
   return <p className={\\"🐻-4138457428\\"} />;

--- a/packages/babel-plugin/src/__test__/__snapshots__/component.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/component.test.ts.snap
@@ -5,7 +5,7 @@ exports[`headless component > using default props should match snapshot 1`] = `
 .🐻-1587700805 { color: green;text-decoration: line-through;font-size: 16px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { Text } from '@kuma-ui/core';
 function App() {
   return <p className={\\"🐻-1587700805\\"} />;
@@ -18,7 +18,7 @@ exports[`headless component > using default props with inline props should match
 .🐻-4138457428 { color: blue;text-decoration: line-through;font-size: 12px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { Text } from '@kuma-ui/core';
 function App() {
   return <p className={\\"🐻-4138457428\\"} />;

--- a/packages/babel-plugin/src/__test__/__snapshots__/css.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/css.test.ts.snap
@@ -5,7 +5,7 @@ exports[`css function > Snapshot tests > basic usage should match snapshot 1`] =
 .🐻-136547911{color:red;}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { css } from '@kuma-ui/core';
 const style = \\"🐻-136547911\\";
 "
@@ -16,7 +16,7 @@ exports[`css function > Snapshot tests > using pseudo props should match snapsho
 .🐻-714656561:hover{color:red;}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { css } from '@kuma-ui/core';
 const style = \\"🐻-714656561\\";
 "
@@ -27,7 +27,7 @@ exports[`css function > Snapshot tests > using space props should match snapshot
 .🐻-620795649{padding:2px;}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { css } from '@kuma-ui/core';
 const style = \\"🐻-620795649\\";
 "

--- a/packages/babel-plugin/src/__test__/__snapshots__/css.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/css.test.ts.snap
@@ -5,7 +5,7 @@ exports[`css function > Snapshot tests > basic usage should match snapshot 1`] =
 .🐻-136547911{color:red;}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { css } from '@kuma-ui/core';
 const style = \\"🐻-136547911\\";
 "
@@ -16,7 +16,7 @@ exports[`css function > Snapshot tests > using pseudo props should match snapsho
 .🐻-714656561:hover{color:red;}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { css } from '@kuma-ui/core';
 const style = \\"🐻-714656561\\";
 "
@@ -27,7 +27,7 @@ exports[`css function > Snapshot tests > using space props should match snapshot
 .🐻-620795649{padding:2px;}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { css } from '@kuma-ui/core';
 const style = \\"🐻-620795649\\";
 "

--- a/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
@@ -5,7 +5,7 @@ exports[`k api > Snapshot tests (runtime: automatic) > basic usage should match 
 .🐻-4229161508 { font-size: 24px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-4229161508\\"}></div>;
@@ -18,7 +18,7 @@ exports[`k api > Snapshot tests (runtime: automatic) > should match snapshot whe
 .🐻-4229161508 { font-size: 24px; } .🐻-4229161508 { font-size: 24px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-4229161508\\"}><div className={\\"🐻-4229161508\\"}></div></div>;
@@ -31,7 +31,7 @@ exports[`k api > Snapshot tests (runtime: automatic) > using className prop shou
 .🐻-2131929892 { padding: 2px; }.🐻-2131929892:hover { color: red; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k, css } from '@kuma-ui/core';
 function App() {
   return <div className={\`🐻-2131929892 \${css({
@@ -46,7 +46,7 @@ exports[`k api > Snapshot tests (runtime: automatic) > using pseudo elements sho
 .🐻-2631981251 { padding: 2px; }.🐻-2631981251:after { color: blue; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-2631981251\\"} />;
@@ -59,7 +59,7 @@ exports[`k api > Snapshot tests (runtime: automatic) > using pseudo props should
 .🐻-2131929892 { padding: 2px; }.🐻-2131929892:hover { color: red; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <span className={\\"🐻-2131929892\\"} />;
@@ -72,7 +72,7 @@ exports[`k api > Snapshot tests (runtime: automatic) > using responsive props sh
 .🐻-401969115 { font-size: 16px; }@media (min-width: 576px) { .🐻-401969115 { font-size: 24px; } }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <a className={\\"🐻-401969115\\"} />;
@@ -85,7 +85,7 @@ exports[`k api > Snapshot tests (runtime: automatic) > using space props should 
 .🐻-3206633536 { padding: 2px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-3206633536\\"} />;
@@ -98,7 +98,7 @@ exports[`k api > Snapshot tests (runtime: classic) > basic usage should match sn
 .🐻-4229161508 { font-size: 24px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-4229161508\\"}></div>;
@@ -111,7 +111,7 @@ exports[`k api > Snapshot tests (runtime: classic) > should match snapshot when 
 .🐻-4229161508 { font-size: 24px; } .🐻-4229161508 { font-size: 24px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-4229161508\\"}><div className={\\"🐻-4229161508\\"}></div></div>;
@@ -124,7 +124,7 @@ exports[`k api > Snapshot tests (runtime: classic) > using className prop should
 .🐻-2131929892 { padding: 2px; }.🐻-2131929892:hover { color: red; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k, css } from '@kuma-ui/core';
 function App() {
   return <div className={\`🐻-2131929892 \${css({
@@ -139,7 +139,7 @@ exports[`k api > Snapshot tests (runtime: classic) > using pseudo elements shoul
 .🐻-2631981251 { padding: 2px; }.🐻-2631981251:after { color: blue; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-2631981251\\"} />;
@@ -152,7 +152,7 @@ exports[`k api > Snapshot tests (runtime: classic) > using pseudo props should m
 .🐻-2131929892 { padding: 2px; }.🐻-2131929892:hover { color: red; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <span className={\\"🐻-2131929892\\"} />;
@@ -165,7 +165,7 @@ exports[`k api > Snapshot tests (runtime: classic) > using responsive props shou
 .🐻-401969115 { font-size: 16px; }@media (min-width: 576px) { .🐻-401969115 { font-size: 24px; } }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <a className={\\"🐻-401969115\\"} />;
@@ -178,7 +178,7 @@ exports[`k api > Snapshot tests (runtime: classic) > using space props should ma
 .🐻-3206633536 { padding: 2px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-3206633536\\"} />;
@@ -191,7 +191,7 @@ exports[`k api > Snapshot tests (runtime: undefined) > basic usage should match 
 .🐻-4229161508 { font-size: 24px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-4229161508\\"}></div>;
@@ -204,7 +204,7 @@ exports[`k api > Snapshot tests (runtime: undefined) > should match snapshot whe
 .🐻-4229161508 { font-size: 24px; } .🐻-4229161508 { font-size: 24px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-4229161508\\"}><div className={\\"🐻-4229161508\\"}></div></div>;
@@ -217,7 +217,7 @@ exports[`k api > Snapshot tests (runtime: undefined) > using className prop shou
 .🐻-2131929892 { padding: 2px; }.🐻-2131929892:hover { color: red; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k, css } from '@kuma-ui/core';
 function App() {
   return <div className={\`🐻-2131929892 \${css({
@@ -232,7 +232,7 @@ exports[`k api > Snapshot tests (runtime: undefined) > using pseudo elements sho
 .🐻-2631981251 { padding: 2px; }.🐻-2631981251:after { color: blue; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-2631981251\\"} />;
@@ -245,7 +245,7 @@ exports[`k api > Snapshot tests (runtime: undefined) > using pseudo props should
 .🐻-2131929892 { padding: 2px; }.🐻-2131929892:hover { color: red; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <span className={\\"🐻-2131929892\\"} />;
@@ -258,7 +258,7 @@ exports[`k api > Snapshot tests (runtime: undefined) > using responsive props sh
 .🐻-401969115 { font-size: 16px; }@media (min-width: 576px) { .🐻-401969115 { font-size: 24px; } }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <a className={\\"🐻-401969115\\"} />;
@@ -271,7 +271,7 @@ exports[`k api > Snapshot tests (runtime: undefined) > using space props should 
 .🐻-3206633536 { padding: 2px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-3206633536\\"} />;

--- a/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
@@ -5,7 +5,7 @@ exports[`k api > Snapshot tests (runtime: automatic) > basic usage should match 
 .🐻-4229161508 { font-size: 24px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-4229161508\\"}></div>;
@@ -18,7 +18,7 @@ exports[`k api > Snapshot tests (runtime: automatic) > should match snapshot whe
 .🐻-4229161508 { font-size: 24px; } .🐻-4229161508 { font-size: 24px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-4229161508\\"}><div className={\\"🐻-4229161508\\"}></div></div>;
@@ -31,7 +31,7 @@ exports[`k api > Snapshot tests (runtime: automatic) > using className prop shou
 .🐻-2131929892 { padding: 2px; }.🐻-2131929892:hover { color: red; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k, css } from '@kuma-ui/core';
 function App() {
   return <div className={\`🐻-2131929892 \${css({
@@ -46,7 +46,7 @@ exports[`k api > Snapshot tests (runtime: automatic) > using pseudo elements sho
 .🐻-2631981251 { padding: 2px; }.🐻-2631981251:after { color: blue; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-2631981251\\"} />;
@@ -59,7 +59,7 @@ exports[`k api > Snapshot tests (runtime: automatic) > using pseudo props should
 .🐻-2131929892 { padding: 2px; }.🐻-2131929892:hover { color: red; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <span className={\\"🐻-2131929892\\"} />;
@@ -72,7 +72,7 @@ exports[`k api > Snapshot tests (runtime: automatic) > using responsive props sh
 .🐻-401969115 { font-size: 16px; }@media (min-width: 576px) { .🐻-401969115 { font-size: 24px; } }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <a className={\\"🐻-401969115\\"} />;
@@ -85,7 +85,7 @@ exports[`k api > Snapshot tests (runtime: automatic) > using space props should 
 .🐻-3206633536 { padding: 2px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-3206633536\\"} />;
@@ -98,7 +98,7 @@ exports[`k api > Snapshot tests (runtime: classic) > basic usage should match sn
 .🐻-4229161508 { font-size: 24px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-4229161508\\"}></div>;
@@ -111,7 +111,7 @@ exports[`k api > Snapshot tests (runtime: classic) > should match snapshot when 
 .🐻-4229161508 { font-size: 24px; } .🐻-4229161508 { font-size: 24px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-4229161508\\"}><div className={\\"🐻-4229161508\\"}></div></div>;
@@ -124,7 +124,7 @@ exports[`k api > Snapshot tests (runtime: classic) > using className prop should
 .🐻-2131929892 { padding: 2px; }.🐻-2131929892:hover { color: red; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k, css } from '@kuma-ui/core';
 function App() {
   return <div className={\`🐻-2131929892 \${css({
@@ -139,7 +139,7 @@ exports[`k api > Snapshot tests (runtime: classic) > using pseudo elements shoul
 .🐻-2631981251 { padding: 2px; }.🐻-2631981251:after { color: blue; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-2631981251\\"} />;
@@ -152,7 +152,7 @@ exports[`k api > Snapshot tests (runtime: classic) > using pseudo props should m
 .🐻-2131929892 { padding: 2px; }.🐻-2131929892:hover { color: red; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <span className={\\"🐻-2131929892\\"} />;
@@ -165,7 +165,7 @@ exports[`k api > Snapshot tests (runtime: classic) > using responsive props shou
 .🐻-401969115 { font-size: 16px; }@media (min-width: 576px) { .🐻-401969115 { font-size: 24px; } }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <a className={\\"🐻-401969115\\"} />;
@@ -178,7 +178,7 @@ exports[`k api > Snapshot tests (runtime: classic) > using space props should ma
 .🐻-3206633536 { padding: 2px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-3206633536\\"} />;
@@ -191,7 +191,7 @@ exports[`k api > Snapshot tests (runtime: undefined) > basic usage should match 
 .🐻-4229161508 { font-size: 24px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-4229161508\\"}></div>;
@@ -204,7 +204,7 @@ exports[`k api > Snapshot tests (runtime: undefined) > should match snapshot whe
 .🐻-4229161508 { font-size: 24px; } .🐻-4229161508 { font-size: 24px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-4229161508\\"}><div className={\\"🐻-4229161508\\"}></div></div>;
@@ -217,7 +217,7 @@ exports[`k api > Snapshot tests (runtime: undefined) > using className prop shou
 .🐻-2131929892 { padding: 2px; }.🐻-2131929892:hover { color: red; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k, css } from '@kuma-ui/core';
 function App() {
   return <div className={\`🐻-2131929892 \${css({
@@ -232,7 +232,7 @@ exports[`k api > Snapshot tests (runtime: undefined) > using pseudo elements sho
 .🐻-2631981251 { padding: 2px; }.🐻-2631981251:after { color: blue; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-2631981251\\"} />;
@@ -245,7 +245,7 @@ exports[`k api > Snapshot tests (runtime: undefined) > using pseudo props should
 .🐻-2131929892 { padding: 2px; }.🐻-2131929892:hover { color: red; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <span className={\\"🐻-2131929892\\"} />;
@@ -258,7 +258,7 @@ exports[`k api > Snapshot tests (runtime: undefined) > using responsive props sh
 .🐻-401969115 { font-size: 16px; }@media (min-width: 576px) { .🐻-401969115 { font-size: 24px; } }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <a className={\\"🐻-401969115\\"} />;
@@ -271,7 +271,7 @@ exports[`k api > Snapshot tests (runtime: undefined) > using space props should 
 .🐻-3206633536 { padding: 2px; }
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return <div className={\\"🐻-3206633536\\"} />;

--- a/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
@@ -5,16 +5,16 @@ exports[`styled function > Snapshot tests (runtime: automatic) > 'styled' tag ex
 .🐻-3239996223{background:green;}.🐻-1641059616{color:red;}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const GreenButton = props => {
+const GreenButton = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-3239996223\\"].filter(Boolean).join(\\" \\");
-      return <__Box as=\\"button\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
-const GreenButtonRedText = props => {
+      return <__Box as=\\"button\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
+const GreenButtonRedText = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
-      return <GreenButton {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
+      return <GreenButton {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
 function App() {
   return <GreenButton>test</GreenButton>;
 }
@@ -26,12 +26,12 @@ exports[`styled function > Snapshot tests (runtime: automatic) > 'styled' tag fu
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = props => {
+const Box = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
-      return <__Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
+      return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
 function App() {
   return <Box>test</Box>;
 }
@@ -43,12 +43,12 @@ exports[`styled function > Snapshot tests (runtime: automatic) > 'styled' tag pr
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = props => {
+const Box = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
-      return <__Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
+      return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
 function App() {
   return <Box>test</Box>;
 }
@@ -60,12 +60,12 @@ exports[`styled function > Snapshot tests (runtime: automatic) > using className
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { styled, css } from '@kuma-ui/core';
-const Box = props => {
+const Box = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
-      return <__Box as=\\"span\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
+      return <__Box as=\\"span\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
 function App() {
   return <Box className={css({
     boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)'
@@ -81,12 +81,12 @@ exports[`styled function > Snapshot tests (runtime: automatic) > using pseudo el
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = props => {
+const Box = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
-      return <__Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
+      return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
 function App() {
   return <Box>test</Box>;
 }
@@ -98,16 +98,16 @@ exports[`styled function > Snapshot tests (runtime: classic) > 'styled' tag exte
 .🐻-3239996223{background:green;}.🐻-1641059616{color:red;}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const GreenButton = props => {
+const GreenButton = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-3239996223\\"].filter(Boolean).join(\\" \\");
-      return <__Box as=\\"button\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
-const GreenButtonRedText = props => {
+      return <__Box as=\\"button\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
+const GreenButtonRedText = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
-      return <GreenButton {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
+      return <GreenButton {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
 function App() {
   return <GreenButton>test</GreenButton>;
 }
@@ -119,12 +119,12 @@ exports[`styled function > Snapshot tests (runtime: classic) > 'styled' tag func
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = props => {
+const Box = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
-      return <__Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
+      return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
 function App() {
   return <Box>test</Box>;
 }
@@ -136,12 +136,12 @@ exports[`styled function > Snapshot tests (runtime: classic) > 'styled' tag prop
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = props => {
+const Box = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
-      return <__Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
+      return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
 function App() {
   return <Box>test</Box>;
 }
@@ -153,12 +153,12 @@ exports[`styled function > Snapshot tests (runtime: classic) > using className p
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { styled, css } from '@kuma-ui/core';
-const Box = props => {
+const Box = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
-      return <__Box as=\\"span\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
+      return <__Box as=\\"span\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
 function App() {
   return <Box className={css({
     boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)'
@@ -174,12 +174,12 @@ exports[`styled function > Snapshot tests (runtime: classic) > using pseudo elem
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = props => {
+const Box = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
-      return <__Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
+      return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
 function App() {
   return <Box>test</Box>;
 }
@@ -191,16 +191,16 @@ exports[`styled function > Snapshot tests (runtime: undefined) > 'styled' tag ex
 .🐻-3239996223{background:green;}.🐻-1641059616{color:red;}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const GreenButton = props => {
+const GreenButton = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-3239996223\\"].filter(Boolean).join(\\" \\");
-      return <__Box as=\\"button\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
-const GreenButtonRedText = props => {
+      return <__Box as=\\"button\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
+const GreenButtonRedText = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
-      return <GreenButton {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
+      return <GreenButton {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
 function App() {
   return <GreenButton>test</GreenButton>;
 }
@@ -212,12 +212,12 @@ exports[`styled function > Snapshot tests (runtime: undefined) > 'styled' tag fu
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = props => {
+const Box = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
-      return <__Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
+      return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
 function App() {
   return <Box>test</Box>;
 }
@@ -229,12 +229,12 @@ exports[`styled function > Snapshot tests (runtime: undefined) > 'styled' tag pr
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = props => {
+const Box = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
-      return <__Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
+      return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
 function App() {
   return <Box>test</Box>;
 }
@@ -246,12 +246,12 @@ exports[`styled function > Snapshot tests (runtime: undefined) > using className
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { styled, css } from '@kuma-ui/core';
-const Box = props => {
+const Box = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
-      return <__Box as=\\"span\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
+      return <__Box as=\\"span\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
 function App() {
   return <Box className={css({
     boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)'
@@ -267,12 +267,12 @@ exports[`styled function > Snapshot tests (runtime: undefined) > using pseudo el
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
+import __React_Kuma_ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = props => {
+const Box = __React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
-      return <__Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    };
+      return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    });
 function App() {
   return <Box>test</Box>;
 }

--- a/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
@@ -5,13 +5,13 @@ exports[`styled function > Snapshot tests (runtime: automatic) > 'styled' tag ex
 .🐻-3239996223{background:green;}.🐻-1641059616{color:red;}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const GreenButton = __React_Kuma_.forwardRef((props, ref) => {
+const GreenButton = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-3239996223\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"button\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
-const GreenButtonRedText = __React_Kuma_.forwardRef((props, ref) => {
+const GreenButtonRedText = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
       return <GreenButton {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
@@ -26,9 +26,9 @@ exports[`styled function > Snapshot tests (runtime: automatic) > 'styled' tag fu
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = __React_Kuma_.forwardRef((props, ref) => {
+const Box = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
@@ -43,9 +43,9 @@ exports[`styled function > Snapshot tests (runtime: automatic) > 'styled' tag pr
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = __React_Kuma_.forwardRef((props, ref) => {
+const Box = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
@@ -60,9 +60,9 @@ exports[`styled function > Snapshot tests (runtime: automatic) > using className
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { styled, css } from '@kuma-ui/core';
-const Box = __React_Kuma_.forwardRef((props, ref) => {
+const Box = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"span\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
@@ -81,9 +81,9 @@ exports[`styled function > Snapshot tests (runtime: automatic) > using pseudo el
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = __React_Kuma_.forwardRef((props, ref) => {
+const Box = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
@@ -98,13 +98,13 @@ exports[`styled function > Snapshot tests (runtime: classic) > 'styled' tag exte
 .🐻-3239996223{background:green;}.🐻-1641059616{color:red;}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const GreenButton = __React_Kuma_.forwardRef((props, ref) => {
+const GreenButton = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-3239996223\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"button\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
-const GreenButtonRedText = __React_Kuma_.forwardRef((props, ref) => {
+const GreenButtonRedText = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
       return <GreenButton {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
@@ -119,9 +119,9 @@ exports[`styled function > Snapshot tests (runtime: classic) > 'styled' tag func
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = __React_Kuma_.forwardRef((props, ref) => {
+const Box = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
@@ -136,9 +136,9 @@ exports[`styled function > Snapshot tests (runtime: classic) > 'styled' tag prop
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = __React_Kuma_.forwardRef((props, ref) => {
+const Box = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
@@ -153,9 +153,9 @@ exports[`styled function > Snapshot tests (runtime: classic) > using className p
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { styled, css } from '@kuma-ui/core';
-const Box = __React_Kuma_.forwardRef((props, ref) => {
+const Box = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"span\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
@@ -174,9 +174,9 @@ exports[`styled function > Snapshot tests (runtime: classic) > using pseudo elem
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = __React_Kuma_.forwardRef((props, ref) => {
+const Box = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
@@ -191,13 +191,13 @@ exports[`styled function > Snapshot tests (runtime: undefined) > 'styled' tag ex
 .🐻-3239996223{background:green;}.🐻-1641059616{color:red;}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const GreenButton = __React_Kuma_.forwardRef((props, ref) => {
+const GreenButton = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-3239996223\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"button\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
-const GreenButtonRedText = __React_Kuma_.forwardRef((props, ref) => {
+const GreenButtonRedText = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
       return <GreenButton {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
@@ -212,9 +212,9 @@ exports[`styled function > Snapshot tests (runtime: undefined) > 'styled' tag fu
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = __React_Kuma_.forwardRef((props, ref) => {
+const Box = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
@@ -229,9 +229,9 @@ exports[`styled function > Snapshot tests (runtime: undefined) > 'styled' tag pr
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = __React_Kuma_.forwardRef((props, ref) => {
+const Box = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
@@ -246,9 +246,9 @@ exports[`styled function > Snapshot tests (runtime: undefined) > using className
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { styled, css } from '@kuma-ui/core';
-const Box = __React_Kuma_.forwardRef((props, ref) => {
+const Box = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"span\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });
@@ -267,9 +267,9 @@ exports[`styled function > Snapshot tests (runtime: undefined) > using pseudo el
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
-import __React_Kuma_ from \\"react\\";
+import __KUMA_REACT__ from \\"react\\";
 import { styled } from '@kuma-ui/core';
-const Box = __React_Kuma_.forwardRef((props, ref) => {
+const Box = __KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, \\"🐻-101236145\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     });

--- a/packages/babel-plugin/src/ensureReactImport.ts
+++ b/packages/babel-plugin/src/ensureReactImport.ts
@@ -2,11 +2,13 @@ import { NodePath } from "@babel/core";
 import { types } from "@babel/core";
 
 /**
- * Ensures that a React import declaration exists in the given program.
- * If not, it adds the import declaration at the beginning of the program.
+ * Ensures that React is imported in the given program to satisfy JSX's Classic runtime requirement.
+ * This function adds a React import declaration at the beginning of the program with a unique alias to avoid potential naming conflicts.
  *
- * @param {NodePath<t.Program>} programPath - The path to the Program node in the AST.
- * @param {typeof t} t - The Babel types.
+ * Note: The unique alias "__React_Kuma_" is utilized in Kuma's compiler to safely refer to React (e.g., when using React.forwardRef to wrap styled components) without interfering with user-defined variable names.
+ *
+ * @param {NodePath<types.Program>} programPath - The path to the Program node in the AST.
+ * @param {typeof types} t - The Babel types.
  */
 export function ensureReactImport(
   programPath: NodePath<types.Program>,

--- a/packages/babel-plugin/src/ensureReactImport.ts
+++ b/packages/babel-plugin/src/ensureReactImport.ts
@@ -2,10 +2,10 @@ import { NodePath } from "@babel/core";
 import { types } from "@babel/core";
 
 /**
- * Ensures that React is imported in the given program to satisfy JSX's Classic runtime requirement.
- * This function adds a React import declaration at the beginning of the program with a unique alias to avoid potential naming conflicts.
- *
- * Note: The unique alias "__React_Kuma_" is utilized in Kuma's compiler to safely refer to React (e.g., when using React.forwardRef to wrap styled components) without interfering with user-defined variable names.
+ * Ensures React is imported in the given program to satisfy JSX's Classic runtime requirement.
+ * While React might already be imported, we can't determine the specifier name if a default import exists.
+ * Thus, this function adds a separate React import declaration at the beginning of the program with a unique alias "__KUMA_REACT__".
+ * This unique alias allows Kuma's compiler to safely refer to React (e.g., when using React.forwardRef to wrap styled components) without interfering with user-defined variable names.
  *
  * @param {NodePath<types.Program>} programPath - The path to the Program node in the AST.
  * @param {typeof types} t - The Babel types.
@@ -15,7 +15,7 @@ export function ensureReactImport(
   t: typeof types,
 ) {
   const reactImportDeclaration = t.importDeclaration(
-    [t.importDefaultSpecifier(t.identifier("__React_Kuma_"))],
+    [t.importDefaultSpecifier(t.identifier("__KUMA_REACT__"))],
     t.stringLiteral("react"),
   );
   programPath.unshiftContainer("body", reactImportDeclaration);

--- a/packages/babel-plugin/src/ensureReactImport.ts
+++ b/packages/babel-plugin/src/ensureReactImport.ts
@@ -12,19 +12,9 @@ export function ensureReactImport(
   programPath: NodePath<types.Program>,
   t: typeof types,
 ) {
-  let hasReactImport = false;
-
-  programPath.node.body.forEach((node) => {
-    if (t.isImportDeclaration(node) && node.source.value === "react") {
-      hasReactImport = true;
-    }
-  });
-
-  if (!hasReactImport) {
-    const reactImportDeclaration = t.importDeclaration(
-      [t.importDefaultSpecifier(t.identifier("React"))],
-      t.stringLiteral("react"),
-    );
-    programPath.unshiftContainer("body", reactImportDeclaration);
-  }
+  const reactImportDeclaration = t.importDeclaration(
+    [t.importDefaultSpecifier(t.identifier("__React_Kuma_"))],
+    t.stringLiteral("react"),
+  );
+  programPath.unshiftContainer("body", reactImportDeclaration);
 }

--- a/packages/compiler/src/__test__/__snapshots__/styled.test.ts.snap
+++ b/packages/compiler/src/__test__/__snapshots__/styled.test.ts.snap
@@ -7,14 +7,14 @@ exports[`styled tag > should generate code 1`] = `
   
         import { styled } from \\"@kuma-ui/core\\";
         
-        export const GreenButton = props => {
+        export const GreenButton = __React_Kuma_.forwardRef((props, ref) => {
               const combinedClassName = [props.className, \\"🐻-3239996223\\"].filter(Boolean).join(\\" \\");
-              return <Box as=\\"button\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-            }
-        export const GreenButtonRedText = props => {
+              return <Box as=\\"button\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+            })
+        export const GreenButtonRedText = __React_Kuma_.forwardRef((props, ref) => {
               const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
-              return <GreenButton {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-            }
+              return <GreenButton {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+            })
     
   "
 `;
@@ -30,10 +30,10 @@ exports[`styled tag > should only touch 'styled' tag from kuma-ui 1`] = `
         export const One = styled.div\`
           color: green;
         \`
-        export const Two = props => {
+        export const Two = __React_Kuma_.forwardRef((props, ref) => {
               const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
-              return <Box as=\\"div\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-            }
+              return <Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+            })
     
   "
 `;

--- a/packages/compiler/src/__test__/__snapshots__/styled.test.ts.snap
+++ b/packages/compiler/src/__test__/__snapshots__/styled.test.ts.snap
@@ -7,11 +7,11 @@ exports[`styled tag > should generate code 1`] = `
   
         import { styled } from \\"@kuma-ui/core\\";
         
-        export const GreenButton = __React_Kuma_.forwardRef((props, ref) => {
+        export const GreenButton = __KUMA_REACT__.forwardRef((props, ref) => {
               const combinedClassName = [props.className, \\"🐻-3239996223\\"].filter(Boolean).join(\\" \\");
               return <Box as=\\"button\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
             })
-        export const GreenButtonRedText = __React_Kuma_.forwardRef((props, ref) => {
+        export const GreenButtonRedText = __KUMA_REACT__.forwardRef((props, ref) => {
               const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
               return <GreenButton {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
             })
@@ -30,7 +30,7 @@ exports[`styled tag > should only touch 'styled' tag from kuma-ui 1`] = `
         export const One = styled.div\`
           color: green;
         \`
-        export const Two = __React_Kuma_.forwardRef((props, ref) => {
+        export const Two = __KUMA_REACT__.forwardRef((props, ref) => {
               const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
               return <Box as=\\"div\\" {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
             })

--- a/packages/compiler/src/processTaggedTemplateExpression.ts
+++ b/packages/compiler/src/processTaggedTemplateExpression.ts
@@ -64,10 +64,12 @@ function replaceTaggedTemplate(
 ) {
   const className = extractClassName(node.getTemplate());
   if (className) {
-    const replacement = `props => {
+    // Using React.forwardRef to allow the component to receive a ref.
+    // Assuming React is available in this file as __React_Kuma_, as it's being imported in `babel-plugin/src/ensureReactImport.ts`.
+    const replacement = `__React_Kuma_.forwardRef((props, ref) => {
       const combinedClassName = [props.className, "${className}"].filter(Boolean).join(" ");
-      return <${component} {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
-    }`;
+      return <${component} {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
+    })`;
     node.replaceWithText(replacement);
   }
 }

--- a/packages/compiler/src/processTaggedTemplateExpression.ts
+++ b/packages/compiler/src/processTaggedTemplateExpression.ts
@@ -65,8 +65,8 @@ function replaceTaggedTemplate(
   const className = extractClassName(node.getTemplate());
   if (className) {
     // Using React.forwardRef to allow the component to receive a ref.
-    // Assuming React is available in this file as __React_Kuma_, as it's being imported in `babel-plugin/src/ensureReactImport.ts`.
-    const replacement = `__React_Kuma_.forwardRef((props, ref) => {
+    // Assuming React is available in this file as __KUMA_REACT__, as it's being imported in `babel-plugin/src/ensureReactImport.ts`.
+    const replacement = `__KUMA_REACT__.forwardRef((props, ref) => {
       const combinedClassName = [props.className, "${className}"].filter(Boolean).join(" ");
       return <${component} {...props} ref={ref} className={combinedClassName} IS_KUMA_DEFAULT />;
     })`;


### PR DESCRIPTION
###  Summary
This PR allows Kuma UI's styled components created through the `styled` API to accept refs without triggering warnings. The unique alias assures that user-defined variable names are not in conflict with Kuma's internal usage of React.

### Changes
- Adjusted [`ensureReactImport`](https://github.com/kuma-ui/kuma-ui/blob/main/packages/babel-plugin/src/ensureReactImport.ts) to import React as `__React_Kuma_`.
- Modified [`replaceTaggedTemplate`](https://github.com/kuma-ui/kuma-ui/blob/main/packages/compiler/src/processTaggedTemplateExpression.ts) to use `__React_Kuma_.forwardRef` enabling the passing of refs.
