### PR TITLE
Ensure the background effects are fully visible regardless of the aspect ratio

### DIFF
--- a/website/src/components/home/hero.tsx
+++ b/website/src/components/home/hero.tsx
@@ -23,12 +23,15 @@ export const Hero = () => {
     <Box m={["40px auto", "80px auto 0px"]}>
       <Box position="relative">
         <Box role="presentation" display={["initial"]} bg="white">
-          <Box
-            bg="radial-gradient(circle at 75% 50%, hsl(186 75% 85%), rgba(255, 255, 255, 0) 25%), radial-gradient(circle at 60% 30%, hsl(200 75% 85%), rgba(255, 255, 255, 0) 10%)"
-            position="fixed"
-            inset={["0px", "100px"]}
-            zIndex="-1"
-          />
+        <Box
+          bg="radial-gradient(circle at calc(75% - 25px) 50%, hsl(186 75% 85%), rgba(255, 255, 255, 0) 25%), radial-gradient(circle at calc(60% - 25px) 30%, hsl(200 75% 85%), rgba(255, 255, 255, 0) 10%)"
+          position="fixed"
+          top="0px"
+          right="0px"
+          bottom="0px"
+          left="0px"
+          zIndex="-1"
+        />
         </Box>
         <Heading
           fontSize={["2.25rem", "3.25rem"]}

--- a/website/src/components/home/hero.tsx
+++ b/website/src/components/home/hero.tsx
@@ -23,15 +23,15 @@ export const Hero = () => {
     <Box m={["40px auto", "80px auto 0px"]}>
       <Box position="relative">
         <Box role="presentation" display={["initial"]} bg="white">
-        <Box
-          bg="radial-gradient(circle at calc(75% - 25px) 50%, hsl(186 75% 85%), rgba(255, 255, 255, 0) 25%), radial-gradient(circle at calc(60% - 25px) 30%, hsl(200 75% 85%), rgba(255, 255, 255, 0) 10%)"
-          position="fixed"
-          top="0px"
-          right="0px"
-          bottom="0px"
-          left="0px"
-          zIndex="-1"
-        />
+          <Box
+            bg="radial-gradient(circle at calc(75% - 25px) 50%, hsl(186 75% 85%), rgba(255, 255, 255, 0) 25%), radial-gradient(circle at calc(60% - 25px) 30%, hsl(200 75% 85%), rgba(255, 255, 255, 0) 10%)"
+            position="fixed"
+            top="0px"
+            right="0px"
+            bottom="0px"
+            left="0px"
+            zIndex="-1"
+          />
         </Box>
         <Heading
           fontSize={["2.25rem", "3.25rem"]}


### PR DESCRIPTION
## Purpose

I Fixed https://github.com/kuma-ui/kuma-ui/issues/239

## Current problem
- <img width="1014" alt="スクリーンショット 2023-10-20 23 55 26" src="https://github.com/kuma-ui/kuma-ui/assets/50833174/110c4ffa-0174-4991-8517-7063efd2b805">


## Expected Results:
Regardless of the aspect ratio, the effect will not be cut off.

<img width="895" alt="スクリーンショット 2023-10-21 0 21 15" src="https://github.com/kuma-ui/kuma-ui/assets/50833174/9dadf3f7-e46a-4bcc-95ca-dd6b6ed0ae40">


## Concerns & Current Issues:

The current code does not reproduce the background effect accurately.

Using the following code might reproduce the design more precisely; however, there's a concern that the code is complex and challenging to read

```
radial-gradient(circle at calc(calc(calc(100vw - 200px) * 0.75) + 100px) calc(calc(calc(100vh - 200px) * 0.5) + 100px), #bcf0f5, hsla(0, 0%, 100%, 0) calc(calc(100% - 100px) * 0.25)), radial-gradient(circle at calc(calc(calc(100vw - 200px) * 0.6) + 100px) calc(calc(calc(100vh - 200px) * 0.3) + 100px), #bce2f5, hsla(0, 0%, 100%, 0) calc(calc(100% - 100px) * 0.1))
```