### PR TITLE
fix(docs): fix typo in linting docs

### DIFF
--- a/website/src/pages/docs/Recepies/Linting.mdx
+++ b/website/src/pages/docs/Recepies/Linting.mdx
@@ -7,7 +7,7 @@ import { Tabs, Tab } from "nextra-theme-docs";
 
 # Linting
 
-Sinse Kuma UI's [`styled`](/docs/API/styled.mdx) and [`css`](/docs/API/css.mdx) APIs are similar to the ones from Emotion or styled-components,
+Since Kuma UI's [`styled`](/docs/API/styled.mdx) and [`css`](/docs/API/css.mdx) APIs are similar to the ones from Emotion or styled-components,
 you can use [Stylelint](https://stylelint.io/) with [postcss-styled-syntax](https://github.com/hudochenkov/postcss-styled-syntax) to lint your styles in those functions.
 
 For example, if you want to use Stylelint with config [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard) and [stylelint-config-recess-order](https://github.com/stormwarning/stylelint-config-recess-order), you can install the following packages:


### PR DESCRIPTION
This PR fixes the type in the Documentation > Recepies >Linting.