### PR TITLE
fix: background-image property unable to use `url()`

### DIFF
--- a/.changeset/old-buckets-laugh.md
+++ b/.changeset/old-buckets-laugh.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/system": patch
+---
+
+fix: background-image property unable to use url

--- a/packages/core/src/themeTokens.ts
+++ b/packages/core/src/themeTokens.ts
@@ -14,10 +14,11 @@ export type NumberToken =
   | "letterSpacings"
   | "breakpoints";
 
-export type InputThemeTokens = Partial<
-  Record<Exclude<Tokens, NumberToken>, NestedObject<string>> &
-    Record<NumberToken, NestedObject<string | number>>
->;
+export type InputThemeTokens = {
+  [K in Tokens]?: K extends NumberToken
+    ? NestedObject<string | number>
+    : NestedObject<string>;
+};
 
 export type ResultThemeTokens<T extends InputThemeTokens> = {
   [K in keyof T]: Pretty<FlattenObject<Pick<T, K>>>;

--- a/packages/system/src/generator.ts
+++ b/packages/system/src/generator.ts
@@ -36,7 +36,8 @@ export class StyleGenerator {
     for (const [propName, propValue] of Object.entries(props)) {
       if (
         typeof propValue === "string" &&
-        /[a-zA-Z]+\.[a-zA-Z0-9]+/.test(propValue)
+        /[a-zA-Z]+\.[a-zA-Z0-9]+/.test(propValue) &&
+        !/^\w+\(.*\)$/.test(propValue)
       ) {
         const customStyle = findCustomStyle(propValue);
         if (customStyle !== undefined) {


### PR DESCRIPTION
Refer to: https://github.com/kuma-ui/kuma-ui/issues/353

The style generator incorrectly matches expressions like `url(./image.png)` as custom styles. Because custom styles cannot be used within the CSS value function, I have added additional conditional checks for this case.
However, I believe this is a workaround and perhaps we should consider refactoring the logic in L37?