### PR TITLE
avoid false-positive hasDynamicProps

### DIFF
--- a/.changeset/tiny-pots-sparkle.md
+++ b/.changeset/tiny-pots-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/core": patch
+---
+
+avoid false-positive hasDynamicProps

--- a/packages/core/src/components/Box/react/utils.ts
+++ b/packages/core/src/components/Box/react/utils.ts
@@ -11,7 +11,7 @@ function isDynamicProp(key: string) {
 
 export function hasDynamicProps(props: BoxProps) {
   return Object.keys(props).some((key) => {
-    if (isDynamicProp(key)) {
+    if (isDynamicProp(key) && props[key as keyof BoxProps] != null) {
       return true;
     }
     return false;


### PR DESCRIPTION
Fix `Error: StyleSheetRegistry: id: `` not found in idIndexesMap.` error.

This error occurs on unmounting the code below. This is because Kuma renders DynamicBox despite the generated CSS will be empty.

```tsx
const isHoge = false;
<Box color={isHoge ? "red" : undefined} />;
```

This PR fixes `hasDynamicProps` to be more strict.