### PR TITLE
Fix Theme Token Interpolation with Breakpoints

### DIFF
--- a/packages/compiler/src/extractor/extract.ts
+++ b/packages/compiler/src/extractor/extract.ts
@@ -8,25 +8,28 @@ import {
 } from "@kuma-ui/core/components/componentList";
 import { theme } from "@kuma-ui/sheet";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
+type PropValue = any;
+
+/**
+ * Extracts props from a component and returns the generated className and css.
+ */
 export const extractProps = (
   componentName: (typeof componentList)[keyof typeof componentList],
   jsx: JsxOpeningElement | JsxSelfClosingElement,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
-  propsMap: Record<string, any>,
+  propsMap: Record<string, PropValue>,
 ) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
-  const styledProps: { [key: string]: any } = {};
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
-  const pseudoProps: { [key: string]: any } = {};
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
-  const componentProps: { [key: string]: any } = {};
+  const styledProps: { [key: string]: PropValue } = {};
+  const pseudoProps: { [key: string]: PropValue } = {};
+  // props that are unique to the component (i.e., horizontal in <Spacer horizontal />)
+  const componentProps: { [key: string]: PropValue } = {};
 
   const variant = theme.getVariants(componentName);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
-  const baseStyleProps: { [key: string]: any } = {
+  const baseStyleProps: { [key: string]: PropValue } = {
     ...(variant?.baseStyle as Record<string, string>),
   };
 
+  // pre-defined props to be passed to the component (i.e., display="flex" is pre-defined in )
   const systemDefaultProps = componentDefaultProps(componentName);
   const userDefaultProps = variant?.defaultProps;
 

--- a/packages/system/src/generator.test.ts
+++ b/packages/system/src/generator.test.ts
@@ -91,4 +91,33 @@ describe("StyleGenerator class", () => {
       ),
     );
   });
+
+  test("should interpolate theme tokens with breakpoints in styledProps", () => {
+    // Arrange
+    theme.setUserTheme({
+      colors: {
+        primary: "blue",
+        secondary: "green",
+      },
+      breakpoints: {
+        sm: "576px",
+        md: "768px",
+      },
+    });
+
+    const props = {
+      color: ["colors.primary", "colors.secondary"],
+    };
+
+    // Act
+    const { className, css } = new StyleGenerator(props).getStyle();
+
+    // Assert
+    expect(css.replace(/\s/g, "")).toContain(
+      `.${className} { color: blue; } @media (min-width: 576px) { .${className} { color: green; } }`.replace(
+        /\s/g,
+        "",
+      ),
+    );
+  });
 });

--- a/packages/system/src/generator.test.ts
+++ b/packages/system/src/generator.test.ts
@@ -1,7 +1,9 @@
 import { StyleGenerator } from "./generator";
-import { describe, expect, test } from "vitest";
+import { theme } from "@kuma-ui/sheet";
+import { describe, expect, test, afterEach } from "vitest";
 
 describe("StyleGenerator class", () => {
+  afterEach(() => theme.reset());
   test("should correctly generate className and CSS from given styledProps", () => {
     // Arrange
     const props = {
@@ -63,5 +65,30 @@ describe("StyleGenerator class", () => {
 
     expect(className).toBe("");
     expect(css).toBe("");
+  });
+
+  test("should correctly generate className and CSS from given styledProps with theme", () => {
+    // Arrange
+    theme.setUserTheme({
+      colors: {
+        "colors.primary": "red",
+      },
+    });
+    const props = {
+      color: "colors.primary",
+      _hover: { color: "colors.primary" },
+    };
+
+    // Act
+    const { className, css } = new StyleGenerator(props).getStyle();
+
+    // Assert
+    expect(className.startsWith("🐻-")).toBeTruthy();
+    expect(css.replace(/\s/g, "")).toContain(
+      `.${className} { color: red; } .${className}:hover { color: red; }`.replace(
+        /\s/g,
+        "",
+      ),
+    );
   });
 });


### PR DESCRIPTION

This PR is a work in progress (WIP) aimed at addressing the issue reported in [Issue #377](https://github.com/kuma-ui/kuma-ui/issues/377). The goal is to correct the behavior where theme tokens are not being interpolated correctly when used in combination with breakpoints in direct props style declarations.

### Approach
- Following the TDD methodology, a failing test was first written to replicate the issue as seen in commit https://github.com/kuma-ui/kuma-ui/commit/a78de10359598d5a122e8e1ec118dbbd400ad225.
- The next steps involve making necessary changes to the `StyleGenerator` class to ensure that the test passes, thereby resolving the issue.

### Current Status
- The initial test has been added and is currently failing as expected, indicating that the issue is successfully replicated.
- Work is ongoing to adjust the implementation to pass the test.

