### PR TITLE
chore: Use Node.js 18 for codesandbox

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -3,5 +3,5 @@
   "buildCommand": "codesandbox:build",
   "packages": ["packages/*"],
   "sandboxes": ["/example/vite"],
-  "node": "16"
+  "node": "18"
 }


### PR DESCRIPTION
Now, since 2023-09-11, Node.js 16 is no longer LTS version.
When it is also considered that Node.js v18 is used for PR Checks or releasing,
I believe it would be better to use Node.js 18 for codesandbox too.


([Conversation on the relevant in Discord](https://ptb.discord.com/channels/1119672933477011598/1127180003872886794/1177504083737858118))