### PR TITLE
chore(vite): specify vite version as a peer-dependency

### DIFF
--- a/.changeset/friendly-eggs-look.md
+++ b/.changeset/friendly-eggs-look.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/vite": patch
+---
+
+Either Vite 4 or Vite 5 is now required as a peerDependency.

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -42,6 +42,9 @@
   "devDependencies": {
     "vite": "^4.2.1"
   },
+  "peerDependencies": {
+    "vite": "^4 || ^5"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
As the title says.
Vite 5 was recently released and is working fine on my end.
If there are no problems, I would be willing to include Vite 5 in the support.