### PR TITLE
fix:apply theme tokens to pseudo-class

### DIFF
--- a/.changeset/wet-lamps-grin.md
+++ b/.changeset/wet-lamps-grin.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/system": patch
+---
+
+bug fix: Allow theme tokens to be set for pseudo-classes as well

--- a/packages/system/src/generator.test.ts
+++ b/packages/system/src/generator.test.ts
@@ -20,8 +20,8 @@ describe("StyleGenerator class", () => {
     expect(css.replace(/\s/g, "")).toContain(
       `.${className} { font-size: 24px;color: red; }@media (min-width: 576px) { .${className} { color: blue; } }.${className}:hover { color: black; }`.replace(
         /\s/g,
-        "",
-      ),
+        ""
+      )
     );
     expect(css).toContain(`.${className}:hover { color: black; }`);
   });
@@ -75,7 +75,7 @@ describe("StyleGenerator class", () => {
     });
     const props = {
       color: "colors.primary",
-      _hover: { color: "colors.primary" },
+      _hover: { color: "colors.primary", fontSize: 24 },
     };
 
     // Act
@@ -84,10 +84,10 @@ describe("StyleGenerator class", () => {
     // Assert
     expect(className.startsWith("🐻-")).toBeTruthy();
     expect(css.replace(/\s/g, "")).toContain(
-      `.${className} { color: red; } .${className}:hover { color: red; }`.replace(
+      `.${className} { color: red; } .${className}:hover { color: red;font-size: 24px; }`.replace(
         /\s/g,
-        "",
-      ),
+        ""
+      )
     );
   });
 
@@ -106,6 +106,7 @@ describe("StyleGenerator class", () => {
 
     const props = {
       color: ["colors.primary", "colors.secondary"],
+      _hover: { color: ["colors.secondary", "colors.primary"] },
     };
 
     // Act
@@ -113,10 +114,10 @@ describe("StyleGenerator class", () => {
 
     // Assert
     expect(css.replace(/\s/g, "")).toContain(
-      `.${className} { color: blue; } @media (min-width: 576px) { .${className} { color: green; } }`.replace(
+      `.${className} { color: blue; } @media (min-width: 576px) { .${className} { color: green; } } .${className}:hover { color: green; } @media (min-width: 576px) { .${className}:hover { color: blue; } }`.replace(
         /\s/g,
-        "",
-      ),
+        ""
+      )
     );
   });
 });

--- a/packages/system/src/generator.test.ts
+++ b/packages/system/src/generator.test.ts
@@ -20,8 +20,8 @@ describe("StyleGenerator class", () => {
     expect(css.replace(/\s/g, "")).toContain(
       `.${className} { font-size: 24px;color: red; }@media (min-width: 576px) { .${className} { color: blue; } }.${className}:hover { color: black; }`.replace(
         /\s/g,
-        ""
-      )
+        "",
+      ),
     );
     expect(css).toContain(`.${className}:hover { color: black; }`);
   });
@@ -86,8 +86,8 @@ describe("StyleGenerator class", () => {
     expect(css.replace(/\s/g, "")).toContain(
       `.${className} { color: red; } .${className}:hover { color: red;font-size: 24px; }`.replace(
         /\s/g,
-        ""
-      )
+        "",
+      ),
     );
   });
 
@@ -116,8 +116,8 @@ describe("StyleGenerator class", () => {
     expect(css.replace(/\s/g, "")).toContain(
       `.${className} { color: blue; } @media (min-width: 576px) { .${className} { color: green; } } .${className}:hover { color: green; } @media (min-width: 576px) { .${className}:hover { color: blue; } }`.replace(
         /\s/g,
-        ""
-      )
+        "",
+      ),
     );
   });
 });

--- a/packages/system/src/generator.ts
+++ b/packages/system/src/generator.ts
@@ -143,7 +143,7 @@ export class StyleGenerator {
 
     let css = `.${this.className} { ${this.style.base} }`;
     for (const [breakpoint, cssValue] of Object.entries(
-      this.style.responsive
+      this.style.responsive,
     )) {
       css += `@media (min-width: ${breakpoint}) { .${this.className} { ${cssValue} } }`;
     }

--- a/packages/system/src/generator.ts
+++ b/packages/system/src/generator.ts
@@ -50,6 +50,15 @@ export class StyleGenerator {
         !/^\w+\(.*\)$/.test(propValue) // exclude CSS functions
       );
     };
+
+    /**
+     * If the argument value is a user theme defined in the `kuma.config.ts` file, it is converted,
+     * otherwise the value of value is returned as is.
+     * @example
+     * convertStyle("color", "colors.primary") // returns "#000000"
+     * convertStyle("color", ['colors.primary', 'colors.secondary']) // returns ["#000000", "#ffffff"]
+     * convertStyle("color", "#ffffff") // returns "#ffffff"
+     */
     /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return -- FIXME */
     const convertStyle = (name: string, value: any) => {
       // color={['colors.primary', 'colors.secondary']}
@@ -69,6 +78,7 @@ export class StyleGenerator {
         if (customStyle !== undefined) {
           return customStyle;
         }
+        // color="#ffffff"
       } else if (isStyledProp(name)) {
         return value;
       }

--- a/packages/system/src/generator.ts
+++ b/packages/system/src/generator.ts
@@ -50,40 +50,46 @@ export class StyleGenerator {
         !/^\w+\(.*\)$/.test(propValue) // exclude CSS functions
       );
     };
-
-    for (const [propName, propValue] of Object.entries(props)) {
+    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return -- FIXME */
+    const convertStyle = (name: string, value: any) => {
       // color={['colors.primary', 'colors.secondary']}
-      if (Array.isArray(propValue)) {
-        styledProps[propName] = propValue.map((value) => {
-          if (isThemeStyle(value)) {
-            const customStyle = findThemeStyle(value);
+      if (Array.isArray(value)) {
+        return value.map((v) => {
+          if (isThemeStyle(v)) {
+            const customStyle = findThemeStyle(v);
             if (customStyle !== undefined) {
               return customStyle;
             }
           }
-          return value;
+          return v;
         });
-      }
-      // color="colors.primary"
-      else if (isThemeStyle(propValue)) {
-        const customStyle = findThemeStyle(propValue);
+        // color="colors.primary"
+      } else if (isThemeStyle(value)) {
+        const customStyle = findThemeStyle(value);
         if (customStyle !== undefined) {
-          styledProps[propName] = customStyle;
+          return customStyle;
         }
-      } else if (isStyledProp(propName)) {
-        styledProps[propName] = propValue;
-      } else if (isPseudoProps(propName)) {
+      } else if (isStyledProp(name)) {
+        return value;
+      }
+      return value;
+    };
+    // eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return -- FIXME
+
+    for (const [propName, propValue] of Object.entries(props)) {
+      if (isPseudoProps(propName)) {
         pseudoProps[propName] = propValue;
         for (const [name, value] of Object.entries(propValue)) {
-          if (isThemeStyle(value)) {
-            const customStyle = findThemeStyle(value);
-            if (customStyle !== undefined) {
-              pseudoProps[propName] = {
-                [name]: customStyle,
-              };
-            }
-          }
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+          pseudoProps[propName] = {
+            ...pseudoProps[propName],
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+            [name]: convertStyle(name, value),
+          };
         }
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
+        styledProps[propName] = convertStyle(propName, propValue);
       }
     }
 
@@ -127,7 +133,7 @@ export class StyleGenerator {
 
     let css = `.${this.className} { ${this.style.base} }`;
     for (const [breakpoint, cssValue] of Object.entries(
-      this.style.responsive,
+      this.style.responsive
     )) {
       css += `@media (min-width: ${breakpoint}) { .${this.className} { ${cssValue} } }`;
     }


### PR DESCRIPTION
fix: https://github.com/kuma-ui/kuma-ui/issues/376
The original process would have overwritten all objects if the theme token had been applied to the pseudo-class.
Changed to add properties to objects.