### PR TITLE
Fix the error on invalid style

### DIFF
--- a/.changeset/eleven-papayas-try.md
+++ b/.changeset/eleven-papayas-try.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/core": patch
+---
+
+Fix `DOMException: Failed to execute 'deleteRule' on 'CSSStyleSheet': The index provided (4294967295) is larger than the maximum index (0).`

--- a/packages/core/src/registry/sheet/ClientStyleSheet.ts
+++ b/packages/core/src/registry/sheet/ClientStyleSheet.ts
@@ -82,6 +82,10 @@ export class ClientStyleSheet implements StyleSheet {
   }
 
   public deleteRule(index: number): void {
+    if (index === -1) {
+      return;
+    }
+
     if (this.speedy) {
       const sheet = this.getLatestSheet();
       sheet.deleteRule(index);

--- a/packages/core/src/registry/sheet/ClientStyleSheet.ts
+++ b/packages/core/src/registry/sheet/ClientStyleSheet.ts
@@ -82,7 +82,7 @@ export class ClientStyleSheet implements StyleSheet {
   }
 
   public deleteRule(index: number): void {
-    if (index === -1) {
+    if (index < 0) {
       return;
     }
 

--- a/packages/core/src/registry/sheet/ServerStyleSheet.ts
+++ b/packages/core/src/registry/sheet/ServerStyleSheet.ts
@@ -63,7 +63,7 @@ export class ServerStyleSheet implements StyleSheet {
   }
 
   public deleteRule(index: number): void {
-    if (index === -1) {
+    if (index < 0) {
       return;
     }
 

--- a/packages/core/src/registry/sheet/ServerStyleSheet.ts
+++ b/packages/core/src/registry/sheet/ServerStyleSheet.ts
@@ -63,6 +63,10 @@ export class ServerStyleSheet implements StyleSheet {
   }
 
   public deleteRule(index: number): void {
+    if (index === -1) {
+      return;
+    }
+
     const sheet = this.getSheet();
     sheet.deleteRule(index);
     sheet.insertRule(this.deletedRulePlaceholder, index);


### PR DESCRIPTION
The index of rules can be `-1` if the insertion fails.

https://github.com/kuma-ui/kuma-ui/blob/0013d4a17aaafa94e95e5adb404c6f3111e6563a/packages/core/src/registry/sheet/ClientStyleSheet.ts#L64-L76

Then, deleting them [here](https://github.com/kuma-ui/kuma-ui/blob/cb37a56310bb412801e96302c7f41176c068ae7c/packages/core/src/registry/StyleSheetRegistry.ts#L66) results in the error below.

```
DOMException: Failed to execute 'deleteRule' on 'CSSStyleSheet': The index provided (4294967295) is larger than the maximum index (0).
```

Fixing it by just ignoring negative index on deletion.