### PR TITLE
Temporary Workaround for HMR in Next.js Client Components with Real CSS Output

### DIFF
--- a/example/next-app-router/.gitignore
+++ b/example/next-app-router/.gitignore
@@ -11,6 +11,7 @@
 # next.js
 /.next/
 /out/
+/.kuma/
 
 # production
 /build

--- a/example/next-app-router/next.config.mjs
+++ b/example/next-app-router/next.config.mjs
@@ -5,4 +5,4 @@ const nextConfig = {
   reactStrictMode: true,
 };
 
-export default withKumaUI(nextConfig, {outputDir: "./.kuma"});
+export default withKumaUI(nextConfig);

--- a/example/next-app-router/next.config.mjs
+++ b/example/next-app-router/next.config.mjs
@@ -5,4 +5,4 @@ const nextConfig = {
   reactStrictMode: true,
 };
 
-export default withKumaUI(nextConfig);
+export default withKumaUI(nextConfig, {outputDir: "./.kuma"});

--- a/example/next-app-router/src/app/layout.tsx
+++ b/example/next-app-router/src/app/layout.tsx
@@ -17,9 +17,7 @@ const Layout: FC<Props> = ({ children }) => {
       </head>
       <body>
         <KumaRegistry>
-          <k.div bg={"red"} className={inter.className}>
-            {children}
-          </k.div>
+          <k.div className={inter.className}>{children}</k.div>
         </KumaRegistry>
       </body>
     </html>

--- a/example/next-app-router/src/app/page.tsx
+++ b/example/next-app-router/src/app/page.tsx
@@ -2,7 +2,6 @@
 import { k, Box, css, styled } from "@kuma-ui/core";
 import { Dynamic } from "./dynamic";
 import { Dynamic2 } from "./dynamic2";
-import { B } from "million/dist/block-6b711a9d";
 
 export default function Home() {
   return (

--- a/example/next-app-router/src/app/page.tsx
+++ b/example/next-app-router/src/app/page.tsx
@@ -1,60 +1,24 @@
+"use client";
 import { k, Box, css, styled } from "@kuma-ui/core";
 import { Dynamic } from "./dynamic";
 import { Dynamic2 } from "./dynamic2";
+import { B } from "million/dist/block-6b711a9d";
 
 export default function Home() {
   return (
-    <div>
-      <k.header
-        height={56}
-        fontSize={"fontSizes.y.z"}
-        fontWeight={"fontWeights.super_bold"}
-        fontFamily={"fonts.a"}
-        letterSpacing={(() => "letterSpacings.space_300" as const)()}
-        lineHeight={"lineHeights.sx"}
-      >
-        <k.div
-          maxWidth={1200}
-          fontSize={32}
-          fontWeight="600"
-          fontFamily="quicksand"
-          mx="auto"
-          color="green"
-        >
-          Kuma UI
-        </k.div>
-      </k.header>
-      <Dynamic key={1} />
-      <Dynamic key={2} />
-      <Dynamic2 />
-      <Box color={(() => "colors.blue")()}>dynamic</Box>
-      <Box variant={(() => "action" as const)()}>dynamic</Box>
-      <Box p={[8, 16]} color="colors.green">
-        static
-      </Box>
-      <div
-        className={css`
-          background-color: gray;
-        `}
-      >
-        css
-      </div>
-      <StyledFn>styled fn</StyledFn>
-      <StyledProperty>styled property</StyledProperty>
-      <StyledExtended>styled extended</StyledExtended>
-      <k.button _hover={{
-        bgColor: "colors.blue"
-      }}
-      _active={{
-        bgColor: "colors.red.100"
-      }}
-      >psuedo button</k.button>
-    </div>
+    <Box>
+      <Box color="yellow">hello</Box>
+      <StyledFn />
+      <StyledProperty />
+      <StyledExtended />
+    </Box>
   );
 }
 
 const StyledFn = styled("div")`
   background-color: lightblue;
+  height: 100px;
+  width: 100px;
 `;
 
 const StyledProperty = styled.button`
@@ -63,4 +27,4 @@ const StyledProperty = styled.button`
 
 const StyledExtended = styled(StyledProperty)`
   color: orange;
-`
+`;

--- a/packages/next-plugin/src/index.ts
+++ b/packages/next-plugin/src/index.ts
@@ -6,6 +6,13 @@ import { lazyPostCSS } from "next/dist/build/webpack/config/blocks/css/index.js"
 import { getGlobalCssLoader } from "next/dist/build/webpack/config/blocks/css/loaders/index.js";
 import type { ConfigurationContext } from "next/dist/build/webpack/config/utils.js";
 
+/** 
+This config sets destination directory for generated CSS files which is a temporary workaround to enable HMR in Next.js client components.
+Do not document this option as it will be removed once the issue is fixed.
+NOTE: Any emitted CSS files under ./next directory will be ignored by Next.js. Thus, we need to emit CSS files under some other directory.
+*/
+type KumaConfig = ConstructorParameters<typeof KumaUIWebpackPlugin>[0];
+
 const getSupportedBrowsers = (dir: string, isDevelopment: boolean) => {
   try {
     return browserslist.loadConfig({
@@ -17,7 +24,10 @@ const getSupportedBrowsers = (dir: string, isDevelopment: boolean) => {
   return undefined;
 };
 
-const kumaUiConfig = (nextConfig: NextConfig): NextConfig => {
+const kumaUiConfig = (
+  nextConfig: NextConfig,
+  kumaUiConfig: KumaConfig = {},
+): NextConfig => {
   return {
     webpack(config: Configuration & ConfigurationContext, options) {
       const { dir, dev, isServer } = options;
@@ -54,7 +64,11 @@ const kumaUiConfig = (nextConfig: NextConfig): NextConfig => {
         ),
       });
 
-      config.plugins?.push(new KumaUIWebpackPlugin());
+      config.plugins?.push(
+        new KumaUIWebpackPlugin({
+          outputDir: kumaUiConfig?.outputDir,
+        }),
+      );
       if (typeof nextConfig.webpack === "function") {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- FIXME
         return nextConfig.webpack(config, options);
@@ -64,6 +78,9 @@ const kumaUiConfig = (nextConfig: NextConfig): NextConfig => {
   };
 };
 
-export const withKumaUI = (nextConfig: NextConfig) => {
-  return Object.assign({}, nextConfig, kumaUiConfig(nextConfig));
+export const withKumaUI = (
+  nextConfig: NextConfig,
+  kumaConfig: KumaConfig = {},
+) => {
+  return Object.assign({}, nextConfig, kumaUiConfig(nextConfig, kumaConfig));
 };

--- a/packages/webpack-plugin/assets/package.json
+++ b/packages/webpack-plugin/assets/package.json
@@ -1,3 +1,3 @@
 {
-  "sideEffects": false
+  "sideEffects": true
 }

--- a/packages/webpack-plugin/src/loader.ts
+++ b/packages/webpack-plugin/src/loader.ts
@@ -64,7 +64,7 @@ const kumaUiLoader: RawLoaderDefinitionFunction<Options> = function (
      * Currently, Client Component doesn't account for virtual files, so we need to emit an actual CSS file.
      * TODO: Address and fix this issue.
      */
-    if (outputDir) {
+    if (outputDir && process.env.NODE_ENV !== "production") {
       const codePrefix = fileLoader(css, {
         context: this,
         outputDir: outputDir,

--- a/packages/webpack-plugin/src/loader.ts
+++ b/packages/webpack-plugin/src/loader.ts
@@ -6,12 +6,19 @@ import { createHash } from "crypto";
 import { theme } from "@kuma-ui/sheet";
 import { getUserTheme } from "./getUserTheme";
 import KumaUIWebpackPlugin, { CSS_PATH } from "./plugin";
+import { createRequire } from "module";
 
 export const CSS_PARAM_NAME = "css";
+
+// tsup will replace __ESM__ with true during ESM build and false during CJS build when bundling.
+declare const __ESM__: boolean;
+const _require = __ESM__ ? createRequire(import.meta.url) : require;
+const emptyCssExtractionFile = _require.resolve("../assets/kuma.css");
 
 type Options = {
   config?: string;
   plugin: KumaUIWebpackPlugin;
+  outputDir?: string;
 };
 
 const kumaUiLoader: RawLoaderDefinitionFunction<Options> = function (
@@ -20,7 +27,7 @@ const kumaUiLoader: RawLoaderDefinitionFunction<Options> = function (
   // tell Webpack this loader is async
   const callback = this.async();
   const id = this.resourcePath;
-  const { plugin } = this.getOptions();
+  const { plugin, outputDir } = this.getOptions();
 
   if (plugin.config) {
     // enable automatic rebuild for static theme props
@@ -52,19 +59,34 @@ const kumaUiLoader: RawLoaderDefinitionFunction<Options> = function (
   const css = (result.metadata as unknown as { css: string }).css || "";
 
   if (css) {
+    /**
+     * This is a temporary workaround to enable HMR (Hot Module Replacement) in Next.js client components.
+     * Currently, Client Component doesn't account for virtual files, so we need to emit an actual CSS file.
+     * TODO: Address and fix this issue.
+     */
+    if (outputDir) {
+      const codePrefix = fileLoader(css, {
+        context: this,
+        outputDir: outputDir,
+      });
+      callback(null, `${result.code}\n${codePrefix};`);
+      return;
+    }
+
     const params = new URLSearchParams({ [CSS_PARAM_NAME]: css });
 
     const importCSS = `import ${JSON.stringify(
-      `${this.utils.contextify(this.context, CSS_PATH)}?${params.toString()}`,
+      `${this.utils.contextify(
+        this.context,
+        emptyCssExtractionFile,
+      )}?${params.toString()}`,
     )};`;
 
-    if (plugin.watchMode) {
-      /**
-       * n Next.js version 13.5 and later, changes made in virtual files are no longer recognized by Next.js. Therefore, we need to emit random changes in the entry CSS file to ensure they are taken into account.
-       * @see {@link|https://github.com/vercel/next.js/discussions/59212}
-       */
-      fs.writeFileSync(CSS_PATH, `/* ${Date.now()} */`);
-    }
+    /**
+     * n Next.js version 13.5 and later, changes made in virtual files are no longer recognized by Next.js. Therefore, we need to emit random changes in the entry CSS file to ensure they are taken into account.
+     * @see {@link|https://github.com/vercel/next.js/discussions/59212}
+     */
+    fs.writeFileSync(emptyCssExtractionFile, `/* ${Date.now()} */`);
 
     callback(null, `${result.code}\n${importCSS};`);
     return;
@@ -73,3 +95,23 @@ const kumaUiLoader: RawLoaderDefinitionFunction<Options> = function (
 };
 
 export default kumaUiLoader;
+
+export function fileLoader(
+  src: string,
+  options: {
+    context: LoaderContext<unknown>;
+    outputDir: string;
+  },
+) {
+  const outDir = options.outputDir;
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
+  const hash = createHash("md5").update(src).digest("hex");
+  const srcPath = path.posix.join(outDir, `${hash}.css`);
+  fs.writeFileSync(srcPath, src);
+
+  // Compute the relative path from the current file location to the output directory
+  const currentDir = options.context.context;
+  const relativeSrcPath = path.relative(currentDir, srcPath);
+
+  return `import "${relativeSrcPath}";`;
+}

--- a/packages/webpack-plugin/src/loader.ts
+++ b/packages/webpack-plugin/src/loader.ts
@@ -82,11 +82,13 @@ const kumaUiLoader: RawLoaderDefinitionFunction<Options> = function (
       )}?${params.toString()}`,
     )};`;
 
-    /**
-     * n Next.js version 13.5 and later, changes made in virtual files are no longer recognized by Next.js. Therefore, we need to emit random changes in the entry CSS file to ensure they are taken into account.
-     * @see {@link|https://github.com/vercel/next.js/discussions/59212}
-     */
-    fs.writeFileSync(emptyCssExtractionFile, `/* ${Date.now()} */`);
+    if (plugin.watchMode) {
+      /**
+       * n Next.js version 13.5 and later, changes made in virtual files are no longer recognized by Next.js. Therefore, we need to emit random changes in the entry CSS file to ensure they are taken into account.
+       * @see {@link|https://github.com/vercel/next.js/discussions/59212}
+       */
+      fs.writeFileSync(CSS_PATH, `/* ${Date.now()} */`);
+    }
 
     callback(null, `${result.code}\n${importCSS};`);
     return;

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -20,13 +20,22 @@ export const CSS_PATH = (() => {
   return cssPath;
 })();
 
+type KumaWebpackOptions = {
+  /** The destination to emit an actual CSS file. This is a temporary workaround to enable HMR in Client Component @see loader.ts */
+  outputDir?: string;
+};
+
 class KumaUIWebpackPlugin {
   /* @internal */
   config: string | undefined;
   /* @internal */
   watchMode = false;
 
-  constructor() {
+  private outputDir: string | undefined;
+
+  constructor(options: KumaWebpackOptions = {}) {
+    this.outputDir = options.outputDir;
+
     const dir = readdirSync(".");
     dir.forEach((filePath) => {
       if (filePath.startsWith("kuma.config.")) {
@@ -73,7 +82,7 @@ class KumaUIWebpackPlugin {
         use: [
           {
             loader: _require.resolve("./loader.js"),
-            options: { plugin: this },
+            options: { plugin: this, outputDir: this.outputDir },
           },
         ],
       },


### PR DESCRIPTION
### Context of the Change

([PR #337](https://github.com/kuma-ui/kuma-ui/pull/337)) implemented an approach to handle style updates in development environments. This method involved appending extracted CSS to SearchParams, like so:

```ts
const importCSS = `import ${JSON.stringify(
  `${this.utils.contextify(this.context, CSS_PATH)}?${params.toString()}`,
)};`;
callback(null, `${result.code}\n${importCSS};`);
```

However, we observed that style changes in Client Components did not reflect without a reload when using this approach.

### Addressing the Issue

To address this, we initially attempted to trigger Next.js's HMR by applying arbitrary changes to the actual CSS file set as Entry whenever there were style changes, as described below:

```ts
if (plugin.watchMode) {
  /**
   * In Next.js version 13.5 and later, changes made in virtual files are no longer recognized by Next.js. Therefore, we need to emit random changes in the entry CSS file to ensure they are taken into account.
   * @see {@link|https://github.com/vercel/next.js/discussions/59212}
   */
  fs.writeFileSync(CSS_PATH, `/* ${Date.now()} */`);
}
```

Unfortunately, this method proved unsuccessful, particularly when installing via npm registry, despite working in a pnpm workspace environment.

### Current Workaround

As a temporary solution, I have now shifted to outputting actual CSS files. This workaround allows us to ensure the functionality of HMR in Next.js client components until a more permanent solution can be developed. The relevant changes are applied as follows:


```ts
if (outputDir) {
  const codePrefix = fileLoader(css, {
    context: this,
    outputDir: outputDir,
  });
  callback(null, `${result.code}\n${codePrefix};`);
  return;
}
```

And in `next.config.mjs`, this is specified like:

```mjs
import { withKumaUI } from "@kuma-ui/next-plugin";

const nextConfig = {
  reactStrictMode: true,
};

export default withKumaUI(nextConfig, {outputDir: "./.kuma"});
```

### Moving Forward

Please note that this is a temporary measure. I will not be documenting this workaround as I continue to investigate and develop a more permanent and efficient solution.



