### PR TITLE
docs(website): remove references to non-existent options in install.mdx

### DIFF
--- a/website/src/pages/docs/install.mdx
+++ b/website/src/pages/docs/install.mdx
@@ -100,8 +100,6 @@ Once you've installed the plugin, you need to configure it in your configuration
       plugins: [
         react(),
         KumaUI({
-          // The destination to emit an actual CSS file. If not provided, the CSS will be injected via virtual modules.
-          outputDir: "./.kuma" // Optional
           // Enable WebAssembly support for Kuma UI. Default is false and will use Babel to transpile the code.
           wasm: true // Optional
         }),


### PR DESCRIPTION
## Overview
While reviewing the documentation for kuma-ui, I noticed that there was a reference to a non-existent option in the Vite plugin section. Therefore, I created a Pull Request to remove that reference.

https://github.com/kuma-ui/kuma-ui/blob/0bcf3b0c1dbcba43d4620219f9031d366365d3e6/packages/vite/src/index.ts#L9-L12