### PR TITLE
Add `cx` function for merging multiple class names

### DIFF
--- a/.changeset/thin-toys-collect.md
+++ b/.changeset/thin-toys-collect.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/core": patch
+---
+
+Add `cx` function for merging multiple class names

--- a/packages/core/src/css.test.ts
+++ b/packages/core/src/css.test.ts
@@ -11,8 +11,15 @@ describe("css", () => {
 
 describe("cx", () => {
   test("should merge multiple class names", () => {
-    expect(cx("one", "two", true && "three", false && "four")).toEqual(
-      "one two three",
-    );
+    expect(
+      cx(
+        "one",
+        "two",
+        true && "three",
+        false && "four",
+        null && "five",
+        undefined && "six",
+      ),
+    ).toEqual("one two three");
   });
 });

--- a/packages/core/src/css.test.ts
+++ b/packages/core/src/css.test.ts
@@ -1,10 +1,18 @@
-import { css } from "./css";
+import { css, cx } from "./css";
 import { describe, expect, test } from "vitest";
 
 describe("css", () => {
   test('should throw an error when using the "css" at runtime', () => {
     expect(() => css``).toThrowError(
       'Using the "css" in runtime is not supported.',
+    );
+  });
+});
+
+describe("cx", () => {
+  test("should merge multiple class names", () => {
+    expect(() => cx("one", "two", true && "three", false && "four")).toEqual(
+      "one two three",
     );
   });
 });

--- a/packages/core/src/css.test.ts
+++ b/packages/core/src/css.test.ts
@@ -11,7 +11,7 @@ describe("css", () => {
 
 describe("cx", () => {
   test("should merge multiple class names", () => {
-    expect(() => cx("one", "two", true && "three", false && "four")).toEqual(
+    expect(cx("one", "two", true && "three", false && "four")).toEqual(
       "one two three",
     );
   });

--- a/packages/core/src/css.test.ts
+++ b/packages/core/src/css.test.ts
@@ -11,15 +11,8 @@ describe("css", () => {
 
 describe("cx", () => {
   test("should merge multiple class names", () => {
-    expect(
-      cx(
-        "one",
-        "two",
-        true && "three",
-        false && "four",
-        null && "five",
-        undefined && "six",
-      ),
-    ).toEqual("one two three");
+    expect(cx("one", "two", true && "three", false, null, undefined)).toEqual(
+      "one two three",
+    );
   });
 });

--- a/packages/core/src/css.ts
+++ b/packages/core/src/css.ts
@@ -4,3 +4,7 @@ import { ThemeSystem } from "./theme";
 export const css = (_strings: TemplateStringsArray): string => {
   throw Error('Using the "css" in runtime is not supported.');
 };
+
+export const cx = (...classNames: (string | false | undefined)[]) => (
+	classNames.filter((className) => Boolean(className)).join(' ')
+);

--- a/packages/core/src/css.ts
+++ b/packages/core/src/css.ts
@@ -5,6 +5,5 @@ export const css = (_strings: TemplateStringsArray): string => {
   throw Error('Using the "css" in runtime is not supported.');
 };
 
-export const cx = (...classNames: (string | false | undefined)[]) => (
-	classNames.filter((className) => Boolean(className)).join(' ')
-);
+export const cx = (...classNames: (string | false | undefined)[]) =>
+  classNames.filter((className) => Boolean(className)).join(" ");

--- a/packages/core/src/css.ts
+++ b/packages/core/src/css.ts
@@ -5,5 +5,5 @@ export const css = (_strings: TemplateStringsArray): string => {
   throw Error('Using the "css" in runtime is not supported.');
 };
 
-export const cx = (...classNames: (string | false | undefined)[]) =>
+export const cx = (...classNames: (string | false | null | undefined)[]) =>
   classNames.filter((className) => Boolean(className)).join(" ");

--- a/website/src/pages/docs/API/css.mdx
+++ b/website/src/pages/docs/API/css.mdx
@@ -46,6 +46,38 @@ export const ThisIsTheCSS = () => {
 
 In this example, the `css` function defines a set of styles, generating a className that we then apply to the div component.
 
+### Use `cx` to Combine Multiple Sets of Styles
+
+You can use `cx` to merge multiple style declarations. This is particularly useful for conditional `css` declarations or when importing and combining different style sets.
+
+```tsx copy
+import { css, cx } from "@kuma-ui/core";
+import {resetStyles} from '../my-theme';
+
+export const ThisIsTheCSS = () => {
+  const isLoggedIn = true;
+
+  return (
+    <div
+      className={cx(
+        resetStyles,
+        css`
+          color: white;
+          padding: 8px;
+          background: blue;
+        `,
+        isLoggedIn &&
+          css`
+            color: red;
+          `,
+      )}
+    >
+      hello world
+    </div>
+  );
+};
+```
+
 ## Using Theme Tokens
 
 You can also utilize [theme tokens](/docs/Theme/ThemeTokens) directly within your `css` function. This allows for a more cohesive and centralized way to manage your design values. Here's how you can use it:

--- a/website/src/pages/docs/API/css.mdx
+++ b/website/src/pages/docs/API/css.mdx
@@ -52,7 +52,7 @@ You can use `cx` to merge multiple style declarations. This is particularly usef
 
 ```tsx copy
 import { css, cx } from "@kuma-ui/core";
-import {resetStyles} from '../my-theme';
+import { resetStyles } from "../my-theme";
 
 export const ThisIsTheCSS = () => {
   const isLoggedIn = true;


### PR DESCRIPTION
https://emotion.sh/docs/@emotion/css#cx

Emotion has a `cx` utility function that merges multiple class names. Now, while this function doesn’t do nearly as much (their `cx` function also ensures styles are applied and take priority from left-to-right), having an out-of-the-box (albeit dumb) `cx` function to apply multiple class names would be great. 

```tsx
<div
  className={cx(
    css`
      font-size: 18px;
      color: blue;
    `,
    isLoggedIn &&
      css`
        color: red;
      `
  )}
/>
```