### PR TITLE
Update oxc From v0.12.5 to v0.25.0

### DIFF
--- a/.changeset/pink-olives-perform.md
+++ b/.changeset/pink-olives-perform.md
@@ -1,8 +1,6 @@
 ---
 "@kuma-ui/compiler": patch
 "@kuma-ui/wasm": patch
-"next-app-router": patch
-"react-vite-example": patch
 ---
 
 Update oxc From v0.12.5 to v0.25.0

--- a/.changeset/pink-olives-perform.md
+++ b/.changeset/pink-olives-perform.md
@@ -1,0 +1,8 @@
+---
+"@kuma-ui/compiler": patch
+"@kuma-ui/wasm": patch
+"next-app-router": patch
+"react-vite-example": patch
+---
+
+Update oxc From v0.12.5 to v0.25.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 dependencies = [
  "serde",
 ]
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "castaway"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
 dependencies = [
  "rustversion",
 ]
@@ -65,13 +65,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "compact_str"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
 dependencies = [
  "castaway",
  "cfg-if",
  "itoa",
+ "rustversion",
  "ryu",
  "serde",
  "static_assertions",
@@ -88,37 +89,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
+name = "daachorse"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "63b7ef7a4be509357f4804d0a22e830daddb48f19fd604e4ad32ddce04a94c36"
+
+[[package]]
+name = "dashmap"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown",
  "lock_api",
  "once_cell",
@@ -163,22 +152,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
-name = "index_vec"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74086667896a940438f2118212f313abba4aff3831fef6f4b17d02add5c8bb60"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -220,9 +209,9 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miette"
@@ -250,12 +239,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.4"
+name = "nonmax"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -298,9 +292,9 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "oxc_allocator"
-version = "0.12.5"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e04bd28ba83d7192482b5b39a033f3f942affc37969dbb13919d12d411a1ca9"
+checksum = "466379b9ab2e05996bfedfae9c96753a633bb5a53aaf0898eb0e0ab09e169514"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -309,17 +303,16 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.12.5"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b763cb533569d8aae2c4453ad66a06a249d0f3923ffc2e90353cb48097f6e0e"
+checksum = "34bd4f56fe32adea489153f6d681d9ee01f0336b9b6a89f062611488d8f80797"
 dependencies = [
  "bitflags",
  "num-bigint",
  "oxc_allocator",
- "oxc_index",
+ "oxc_ast_macros",
  "oxc_span",
  "oxc_syntax",
- "ryu-js",
  "serde",
  "serde_json",
  "tsify",
@@ -327,56 +320,98 @@ dependencies = [
 ]
 
 [[package]]
-name = "oxc_codegen"
-version = "0.12.5"
+name = "oxc_ast_macros"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a65b20b2681514a19959ff1aea557bc3c35d0cc6e4176ec836271df0a44175a"
+checksum = "197b36739db0e80919e19a90785233eea5664697d4cd829bd49af34838ec43d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "oxc_cfg"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ee6a0aed5d22fdf543bde5fa6b438b367fb117ee889dc095a827381a3f50dc"
 dependencies = [
  "bitflags",
+ "itertools",
+ "oxc_syntax",
+ "petgraph",
+ "rustc-hash",
+]
+
+[[package]]
+name = "oxc_codegen"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c17d9ec73f9106bf7c8be26da225e96a41805ec933a9536834b354ac400f55"
+dependencies = [
+ "bitflags",
+ "daachorse",
+ "nonmax",
+ "once_cell",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_index",
+ "oxc_mangler",
  "oxc_sourcemap",
  "oxc_span",
  "oxc_syntax",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.12.5"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6485cc36e4f12871e5c8afd79a9f518ebd4ba787c734b8f61e256e3b219bd4"
+checksum = "2cd4bb48b9527f5825c84acb688ec1485df4a5edadc17b3582626bb49736752b"
 dependencies = [
  "miette",
  "owo-colors",
  "textwrap",
- "thiserror",
  "unicode-width",
 ]
 
 [[package]]
 name = "oxc_index"
-version = "0.12.5"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14eb2f1df6412656c1624b4fc2cba5a1e6c1e0aa7752f7a459ef89177cdb8b00"
+checksum = "bc9aa9446f6d2a64d0baa02fe20dc3d64e3e112083854b84fdacb82261be2b84"
 dependencies = [
- "index_vec",
- "static_assertions",
+ "serde",
+]
+
+[[package]]
+name = "oxc_mangler"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fa4277d6c6a93cf587ba2cd7940ac96249d936eb3bb0567eebfdff36bbe5149"
+dependencies = [
+ "itertools",
+ "oxc_ast",
+ "oxc_index",
+ "oxc_semantic",
+ "oxc_span",
 ]
 
 [[package]]
 name = "oxc_parser"
-version = "0.12.5"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee035177fc74ba754171c487f2542a3202a4c4c17f5663ba1867863492321921"
+checksum = "8f3432e80a58cfb38f9a138203e64d0f9a621d4c4e9d18e3e3bd870b51ce1f0e"
 dependencies = [
  "assert-unchecked",
  "bitflags",
  "memchr",
  "num-bigint",
+ "num-traits",
  "oxc_allocator",
  "oxc_ast",
  "oxc_diagnostics",
- "oxc_index",
+ "oxc_regular_expression",
  "oxc_span",
  "oxc_syntax",
  "rustc-hash",
@@ -384,31 +419,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "oxc_semantic"
-version = "0.12.5"
+name = "oxc_regular_expression"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382639e1e3c2631e5fc57824c865606d12fe650c0a0330add51a36a55e62f384"
+checksum = "8fc6d05fec98ad6cc864ba8cfe7ece2e258106059a9a57e35b02450650b06979"
 dependencies = [
+ "oxc_allocator",
+ "oxc_diagnostics",
+ "oxc_span",
+ "phf",
+ "rustc-hash",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "oxc_semantic"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b52913f8fd8efad5a9a4a0c3d437a49a6be9092ddef3ab861fbedee4b343bc2"
+dependencies = [
+ "assert-unchecked",
  "indexmap",
+ "itertools",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_cfg",
  "oxc_diagnostics",
  "oxc_index",
  "oxc_span",
  "oxc_syntax",
- "petgraph",
  "phf",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_sourcemap"
-version = "0.12.5"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4449bd75a521bd5673fbe0e2edfffaa30a406524db324baeecdfe1f1728194"
+checksum = "1dd8e81ebe12ff1c13de9e44cc3d0d187de138cd23e9992959653ecd003d0261"
 dependencies = [
  "base64-simd",
- "rayon",
+ "cfg-if",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -416,12 +467,14 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.12.5"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0667a0c0be4cf13331f768349d66ccab28234906b65cb073693ed3408a023292"
+checksum = "9a862a896ac3abd269863a19d4f77302b019458d90513705c7a017b138c8449b"
 dependencies = [
  "compact_str",
  "miette",
+ "oxc_allocator",
+ "oxc_ast_macros",
  "serde",
  "tsify",
  "wasm-bindgen",
@@ -429,17 +482,20 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.12.5"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a84812216ec90b6485b8527d81f42c2a90d0df05aa61a203a775da67f883e80"
+checksum = "d50c7ea034fb12f65376cfffc8ae4bfde3cda0a1e14407f82ffba1d26431703d"
 dependencies = [
  "bitflags",
  "dashmap",
- "indexmap",
+ "nonmax",
+ "oxc_allocator",
+ "oxc_ast_macros",
  "oxc_index",
  "oxc_span",
  "phf",
  "rustc-hash",
+ "ryu-js",
  "serde",
  "tsify",
  "unicode-id-start",
@@ -461,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -513,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -545,26 +601,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustversion"
@@ -617,9 +653,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.200"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -637,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.200"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -659,11 +695,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -694,9 +731,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -779,9 +816,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "vsimd"

--- a/example/next-app-router/src/app/page.tsx
+++ b/example/next-app-router/src/app/page.tsx
@@ -1,5 +1,4 @@
-"use client";
-import { k, Box, css, styled } from "@kuma-ui/core";
+import { k, Box, css, styled, Text } from "@kuma-ui/core";
 import { Dynamic } from "./dynamic";
 import { Dynamic2 } from "./dynamic2";
 
@@ -12,6 +11,7 @@ export default function Home() {
       <StyledFn />
       <StyledProperty />
       <StyledExtended />
+      <Text color="blue">Hello こんにちわ 你好 สวัสดี</Text>
     </Box>
   );
 }

--- a/example/vite/src/App.tsx
+++ b/example/vite/src/App.tsx
@@ -30,6 +30,7 @@ function App() {
     <Box color="GrayText" border="1px solid" borderColor="orange">
       test
       <Styled>Styled</Styled>
+      <Text>日本語</Text>
       <Dynamic />
     </Box>
   );

--- a/example/vite/vite.config.ts
+++ b/example/vite/vite.config.ts
@@ -8,7 +8,9 @@ import { visualizer } from "rollup-plugin-visualizer";
 export default defineConfig({
   plugins: [
     react(),
-    kumaUI(),
+    kumaUI({
+      wasm: true,
+    }),
     Inspect({
       build: true,
       outputDir: ".inspect",

--- a/packages/compiler/src/__test__/__snapshots__/compileSync.test.ts.snap
+++ b/packages/compiler/src/__test__/__snapshots__/compileSync.test.ts.snap
@@ -30,7 +30,13 @@ exports[`compileSync > wasm > using default props should match snapshot 1`] = `
 "
   .🐻-399577506 { text-decoration: line-through;color: green;font-size: 16px; }
   
-  import {Box as __Box} from '@kuma-ui/core';import __KUMA_REACT__ from 'react';import {Text} from '@kuma-ui/core';function App(){return <p className={\\"🐻-399577506\\"}/>}
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { Text } from \\"@kuma-ui/core\\";
+function App() {
+	return <p className={\\"🐻-399577506\\"} />;
+}
+
   "
 `;
 
@@ -38,6 +44,12 @@ exports[`compileSync > wasm > using default props with inline props should match
 "
   .🐻-2811265315 { text-decoration: line-through;color: blue;font-size: 12px; }
   
-  import {Box as __Box} from '@kuma-ui/core';import __KUMA_REACT__ from 'react';import {Text} from '@kuma-ui/core';function App(){return <p className={\\"🐻-2811265315\\"}/>}
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { Text } from \\"@kuma-ui/core\\";
+function App() {
+	return <p className={\\"🐻-2811265315\\"} />;
+}
+
   "
 `;

--- a/packages/compiler/src/__test__/__snapshots__/css.test.ts.snap
+++ b/packages/compiler/src/__test__/__snapshots__/css.test.ts.snap
@@ -1,5 +1,24 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`css > Snapshot tests with wasm: %p { wasm: false } > Non-English characters should not be escaped 1`] = `
+"
+  .🐻-136547911{color:red;}
+  
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { css } from '@kuma-ui/core';
+const App = () => {
+  return <>
+                  <div className={\\"🐻-136547911\\"}>你好</div>
+                  <div className={\\"🐻-136547911\\"}>こんにちは</div>
+                  <div className={\\"🐻-136547911\\"}>안녕하세요</div>
+                  <div className={\\"🐻-136547911\\"}>สวัสดี</div>
+                  <div className={\\"🐻-136547911\\"}>Xin chào</div>
+                </>;
+};
+  "
+`;
+
 exports[`css > Snapshot tests with wasm: %p { wasm: false } > basic usage should match snapshot 1`] = `
 "
   .🐻-136547911{color:red;}
@@ -33,11 +52,35 @@ const style = \\"🐻-620795649\\";
   "
 `;
 
+exports[`css > Snapshot tests with wasm: %p { wasm: true } > Non-English characters should not be escaped 1`] = `
+"
+  .🐻-136547911{color:red;}
+  
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { css } from \\"@kuma-ui/core\\";
+const App = () => {
+	return <>
+                  <div className={\\"🐻-136547911\\"}>你好</div>
+                  <div className={\\"🐻-136547911\\"}>こんにちは</div>
+                  <div className={\\"🐻-136547911\\"}>안녕하세요</div>
+                  <div className={\\"🐻-136547911\\"}>สวัสดี</div>
+                  <div className={\\"🐻-136547911\\"}>Xin chào</div>
+                </>;
+};
+
+  "
+`;
+
 exports[`css > Snapshot tests with wasm: %p { wasm: true } > basic usage should match snapshot 1`] = `
 "
   .🐻-136547911{color:red;}
   
-  import {Box as __Box} from '@kuma-ui/core';import __KUMA_REACT__ from 'react';import {css} from '@kuma-ui/core';const style=\\"🐻-136547911\\";
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { css } from \\"@kuma-ui/core\\";
+const style = \\"🐻-136547911\\";
+
   "
 `;
 
@@ -45,7 +88,11 @@ exports[`css > Snapshot tests with wasm: %p { wasm: true } > using pseudo props 
 "
   .🐻-2051565201:hover{color:red;}
   
-  import {Box as __Box} from '@kuma-ui/core';import __KUMA_REACT__ from 'react';import {css} from '@kuma-ui/core';const style=\\"🐻-2051565201\\";
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { css } from \\"@kuma-ui/core\\";
+const style = \\"🐻-2051565201\\";
+
   "
 `;
 
@@ -53,6 +100,10 @@ exports[`css > Snapshot tests with wasm: %p { wasm: true } > using space props s
 "
   .🐻-620795649{padding:2px;}
   
-  import {Box as __Box} from '@kuma-ui/core';import __KUMA_REACT__ from 'react';import {css} from '@kuma-ui/core';const style=\\"🐻-620795649\\";
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { css } from \\"@kuma-ui/core\\";
+const style = \\"🐻-620795649\\";
+
   "
 `;

--- a/packages/compiler/src/__test__/__snapshots__/k.test.ts.snap
+++ b/packages/compiler/src/__test__/__snapshots__/k.test.ts.snap
@@ -26,6 +26,23 @@ function App() {
   "
 `;
 
+exports[`k > Snapshot tests with wasm: %p { wasm: false } > should match snapshot when k is used with non-English unicode characters 1`] = `
+"
+     
+  
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { k } from '@kuma-ui/core';
+function App() {
+  return <div>
+                  <div>你好</div>
+                  <div>こんにちは</div>
+                  <div>안녕하세요</div>
+                </div>;
+}
+  "
+`;
+
 exports[`k > Snapshot tests with wasm: %p { wasm: false } > using className prop should match snapshot 1`] = `
 "
   .🐻-2131929892 { padding: 2px; }.🐻-2131929892:hover { color: red; }
@@ -97,7 +114,13 @@ exports[`k > Snapshot tests with wasm: %p { wasm: true } > basic usage should ma
 "
   .🐻-4229161508 { font-size: 24px; }
   
-  import {Box as __Box} from '@kuma-ui/core';import __KUMA_REACT__ from 'react';import {k} from '@kuma-ui/core';function App(){return <div className={\\"🐻-4229161508\\"}></div>}
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { k } from \\"@kuma-ui/core\\";
+function App() {
+	return <div className={\\"🐻-4229161508\\"}></div>;
+}
+
   "
 `;
 
@@ -105,7 +128,31 @@ exports[`k > Snapshot tests with wasm: %p { wasm: true } > should match snapshot
 "
   .🐻-4229161508 { font-size: 24px; } .🐻-4229161508 { font-size: 24px; }
   
-  import {Box as __Box} from '@kuma-ui/core';import __KUMA_REACT__ from 'react';import {k} from '@kuma-ui/core';function App(){return <div className={\\"🐻-4229161508\\"}><div className={\\"🐻-4229161508\\"}></div></div>}
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { k } from \\"@kuma-ui/core\\";
+function App() {
+	return <div className={\\"🐻-4229161508\\"}><div className={\\"🐻-4229161508\\"}></div></div>;
+}
+
+  "
+`;
+
+exports[`k > Snapshot tests with wasm: %p { wasm: true } > should match snapshot when k is used with non-English unicode characters 1`] = `
+"
+     
+  
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { k } from \\"@kuma-ui/core\\";
+function App() {
+	return <div>
+                  <div>你好</div>
+                  <div>こんにちは</div>
+                  <div>안녕하세요</div>
+                </div>;
+}
+
   "
 `;
 
@@ -113,7 +160,13 @@ exports[`k > Snapshot tests with wasm: %p { wasm: true } > using className prop 
 "
   .🐻-2131929892 { padding: 2px; }.🐻-2131929892:hover { color: red; }
   
-  import {Box as __Box} from '@kuma-ui/core';import __KUMA_REACT__ from 'react';import {k,css} from '@kuma-ui/core';function App(){return <div className={\`🐻-2131929892 \${css({boxShadow:'0 1px 2px 0 rgba(0, 0, 0, 0.05)'})}\`}/>}
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { k, css } from \\"@kuma-ui/core\\";
+function App() {
+	return <div className={\`🐻-2131929892 \${css({ boxShadow: \\"0 1px 2px 0 rgba(0, 0, 0, 0.05)\\" })}\`} />;
+}
+
   "
 `;
 
@@ -121,7 +174,13 @@ exports[`k > Snapshot tests with wasm: %p { wasm: true } > using pseudo elements
 "
   .🐻-2631981251 { padding: 2px; }.🐻-2631981251:after { color: blue; }
   
-  import {Box as __Box} from '@kuma-ui/core';import __KUMA_REACT__ from 'react';import {k} from '@kuma-ui/core';function App(){return <div className={\\"🐻-2631981251\\"}/>}
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { k } from \\"@kuma-ui/core\\";
+function App() {
+	return <div className={\\"🐻-2631981251\\"} />;
+}
+
   "
 `;
 
@@ -129,7 +188,13 @@ exports[`k > Snapshot tests with wasm: %p { wasm: true } > using pseudo props sh
 "
   .🐻-2131929892 { padding: 2px; }.🐻-2131929892:hover { color: red; }
   
-  import {Box as __Box} from '@kuma-ui/core';import __KUMA_REACT__ from 'react';import {k} from '@kuma-ui/core';function App(){return <span className={\\"🐻-2131929892\\"}/>}
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { k } from \\"@kuma-ui/core\\";
+function App() {
+	return <span className={\\"🐻-2131929892\\"} />;
+}
+
   "
 `;
 
@@ -137,7 +202,13 @@ exports[`k > Snapshot tests with wasm: %p { wasm: true } > using responsive prop
 "
   .🐻-401969115 { font-size: 16px; }@media (min-width: 576px) { .🐻-401969115 { font-size: 24px; } }
   
-  import {Box as __Box} from '@kuma-ui/core';import __KUMA_REACT__ from 'react';import {k} from '@kuma-ui/core';function App(){return <a className={\\"🐻-401969115\\"}/>}
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { k } from \\"@kuma-ui/core\\";
+function App() {
+	return <a className={\\"🐻-401969115\\"} />;
+}
+
   "
 `;
 
@@ -145,6 +216,12 @@ exports[`k > Snapshot tests with wasm: %p { wasm: true } > using space props sho
 "
   .🐻-3206633536 { padding: 2px; }
   
-  import {Box as __Box} from '@kuma-ui/core';import __KUMA_REACT__ from 'react';import {k} from '@kuma-ui/core';function App(){return <div className={\\"🐻-3206633536\\"}/>}
+  import { Box as __Box } from \\"@kuma-ui/core\\";
+import __KUMA_REACT__ from \\"react\\";
+import { k } from \\"@kuma-ui/core\\";
+function App() {
+	return <div className={\\"🐻-3206633536\\"} />;
+}
+
   "
 `;

--- a/packages/compiler/src/__test__/css.test.ts
+++ b/packages/compiler/src/__test__/css.test.ts
@@ -78,6 +78,27 @@ describe("css", () => {
           getExpectSnapshotSync(originalResult),
         );
       });
+
+      test("Non-English characters should not be escaped", () => {
+        // Arrange
+        const inputCode = `
+              import { css } from '@kuma-ui/core'
+              
+              const App = () => {
+                return <>
+                  <div className={css\`color: red;\`}>你好</div>
+                  <div className={css\`color: red;\`}>こんにちは</div>
+                  <div className={css\`color: red;\`}>안녕하세요</div>
+                  <div className={css\`color: red;\`}>สวัสดี</div>
+                  <div className={css\`color: red;\`}>Xin chào</div>
+                </>
+              }
+            `;
+        // Act
+        const result = compileSync({ code: inputCode, id: "test.tsx", wasm });
+        // Assert
+        expect(getExpectSnapshotSync(result)).toMatchSnapshot();
+      });
     },
   );
 });

--- a/packages/compiler/src/__test__/k.test.ts
+++ b/packages/compiler/src/__test__/k.test.ts
@@ -110,6 +110,26 @@ describe("k", () => {
         // Assert
         expect(getExpectSnapshotSync(result)).toMatchSnapshot();
       });
+
+      test("should match snapshot when k is used with non-English unicode characters", () => {
+        // Arrange
+        const inputCode = `
+            import { k } from '@kuma-ui/core'
+            function App() {
+              return (
+                <k.div>
+                  <k.div>你好</k.div>
+                  <k.div>こんにちは</k.div>
+                  <k.div>안녕하세요</k.div>
+                </k.div>
+              )
+            }
+          `;
+        // Act
+        const result = compileSync({ code: inputCode, id: "test.tsx", wasm });
+        // Assert
+        expect(getExpectSnapshotSync(result)).toMatchSnapshot();
+      });
     },
   );
 });

--- a/packages/wasm/Cargo.toml
+++ b/packages/wasm/Cargo.toml
@@ -12,16 +12,16 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2.84"
-oxc_parser = "0.12.5"
-oxc_allocator = "0.12.5"
-oxc_span = "0.12.5"
+oxc_parser = "0.25.0"
+oxc_allocator = "0.25.0"
+oxc_span = "0.25.0"
 serde = "1.0.198"
 serde-wasm-bindgen = "0.6.5"
-oxc_ast = { "version" =  "0.12.5", features = ["serialize"] }
+oxc_ast = { "version" =  "0.25.0", features = ["serialize"] }
 tsify = "0.4.5"
 web-sys = {"version" = "0.3.44", features=['console']}
-oxc_semantic = "0.12.5"
-oxc_codegen = "0.12.5"
+oxc_semantic = "0.25.0"
+oxc_codegen = "0.25.0"
 serde_json = "1.0.116"
 
 [dev-dependencies]

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -28,6 +28,7 @@
   },
   "scripts": {
     "build": "run-p build:*",
-    "build:wasm": "wasm-pack build --target web --out-dir ./pkg/esm --out-name index && wasm-pack build --target nodejs --out-dir ./pkg/node --out-name index && node script.js"
+    "build:wasm": "wasm-pack build --target web --out-dir ./pkg/esm --out-name index && wasm-pack build --target nodejs --out-dir ./pkg/node --out-name index && node script.js",
+    "test": "cargo test"
   }
 }

--- a/packages/wasm/src/lib.rs
+++ b/packages/wasm/src/lib.rs
@@ -10,9 +10,11 @@ use wasm_bindgen::prelude::*;
 
 mod js_source;
 mod transform;
+mod util;
 
 use js_source::JsSource;
 use transform::Transform;
+use util::replace_quotes_and_newlines;
 
 #[wasm_bindgen(typescript_custom_section)]
 const TYPES: &'static str = r#"
@@ -41,14 +43,52 @@ pub fn transform_sync(source_text: String, extension: String) -> Result<JsValue,
 
     let imports = transform.get_imports();
 
-    let source_text = Codegen::<true>::new("", &source_text, CodegenOptions::default())
+    let source_text = Codegen::new()
+        .with_options(CodegenOptions::default())
         .build(program)
         .source_text;
 
     let output = Output {
-        code: source_text,
+        code: source_text.to_owned(),
         imports: imports.clone(),
     };
 
     JsValue::from_serde(&output).map_err(|err| JsValue::from_str(&format!("{}", err)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_transform_sync() {
+        let source_text = "
+            import {k, Box} from '@kuma-ui/core';
+            export const App = () => {
+                return <k.div><k.span>hello</k.span></k.div>;
+            }
+        ";
+        let extension = "tsx".to_string();
+
+        let allocator = Allocator::default();
+
+        let program = JsSource::new(source_text, extension).to_program(&allocator);
+        let mut transform = Transform::new(&allocator);
+
+        transform.transform(program);
+
+        let imports = transform.get_imports();
+
+        let source_text = Codegen::new()
+            .with_options(CodegenOptions::default())
+            .build(program)
+            .source_text;
+
+        let source_text = replace_quotes_and_newlines(&source_text);
+
+        assert_eq!(
+            source_text,
+            "import __KUMA_REACT__ from 'react';import { k, Box } from '@kuma-ui/core';export const App = () => {return <Box as='div' IS_KUMA_DEFAULT={true}><Box as='span' IS_KUMA_DEFAULT={true}>hello</Box></Box>;};"
+        );
+    }
 }

--- a/packages/wasm/src/transform/visit/collect_import_bindings.rs
+++ b/packages/wasm/src/transform/visit/collect_import_bindings.rs
@@ -27,7 +27,7 @@ impl<'a> Visit<'a> for CollectImportBindings<'a, '_> {
             if let Some(specifiers) = &decl.specifiers {
                 for specifier in specifiers.iter() {
                     if let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier {
-                        if let ModuleExportName::Identifier(imported) = &specifier.imported {
+                        if let ModuleExportName::IdentifierName(imported) = &specifier.imported {
                             let name = imported.name.to_string();
                             let local_name = specifier.local.name.to_string();
 

--- a/packages/wasm/src/transform/visit/ensure_react_import.rs
+++ b/packages/wasm/src/transform/visit/ensure_react_import.rs
@@ -85,6 +85,6 @@ mod test {
             .with_options(Default::default())
             .build(program)
             .source_text;
-        assert_eq!(source, "import __KUMA_REACT__ from 'react';")
+        assert_eq!(source, "import __KUMA_REACT__ from \"react\";\n")
     }
 }

--- a/packages/wasm/src/transform/visit/import_box.rs
+++ b/packages/wasm/src/transform/visit/import_box.rs
@@ -105,9 +105,7 @@ mod test {
         let source = Codegen::new()
             .with_options(Default::default())
             .build(program)
-            .source_text
-            .replace("\"", "'")
-            .replace("\n", "");
-        assert_eq!(source, "import {Box as __Box} from '@kuma-ui/core';")
+            .source_text;
+        assert_eq!(source, "import { Box as __Box } from \"@kuma-ui/core\";\n")
     }
 }

--- a/packages/wasm/src/transform/visit/import_box.rs
+++ b/packages/wasm/src/transform/visit/import_box.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
         ImportOrExportKind, ImportSpecifier, ModuleDeclaration, ModuleExportName, Program,
         Statement, StringLiteral,
     },
-    visit::walk_mut::walk_program_mut,
+    visit::walk_mut::walk_program,
     AstBuilder, VisitMut,
 };
 use oxc_span::{Atom, SPAN};
@@ -51,7 +51,7 @@ impl<'a> VisitMut<'a> for ImportBox<'a, '_> {
                 name: Atom::from("Box"),
             };
 
-            let imported = ModuleExportName::Identifier(identifier_name);
+            let imported = ModuleExportName::IdentifierName(identifier_name);
 
             let specifier =
                 ImportDeclarationSpecifier::ImportSpecifier(self.ast.alloc(ImportSpecifier {
@@ -63,28 +63,27 @@ impl<'a> VisitMut<'a> for ImportBox<'a, '_> {
 
             let import_declaration = ImportDeclaration {
                 span: SPAN,
-                specifiers: Some(self.ast.new_vec_single(specifier)),
+                specifiers: Some(self.ast.vec1(specifier)),
                 source: source_literal,
                 with_clause: None,
                 import_kind: ImportOrExportKind::Value,
             };
 
-            let module_declaration =
-                ModuleDeclaration::ImportDeclaration(self.ast.alloc(import_declaration));
-
-            let import_statement = Statement::ModuleDeclaration(self.ast.alloc(module_declaration));
+            let import_statement = Statement::ImportDeclaration(self.ast.alloc(import_declaration));
 
             self.imports.insert("Box".to_string(), "__Box".to_string());
 
             program.body.insert(0, import_statement);
         }
 
-        walk_program_mut(self, program)
+        walk_program(self, program)
     }
 }
 
 #[cfg(test)]
 mod test {
+    use std::mem::replace;
+
     use super::*;
     use crate::js_source::JsSource;
     use oxc_allocator::Allocator;
@@ -103,9 +102,12 @@ mod test {
 
         import_box.visit_program(program);
 
-        let source = Codegen::<true>::new("", &source_text, Default::default())
+        let source = Codegen::new()
+            .with_options(Default::default())
             .build(program)
-            .source_text;
+            .source_text
+            .replace("\"", "'")
+            .replace("\n", "");
         assert_eq!(source, "import {Box as __Box} from '@kuma-ui/core';")
     }
 }

--- a/packages/wasm/src/transform/visit/replace_k_with_box.rs
+++ b/packages/wasm/src/transform/visit/replace_k_with_box.rs
@@ -142,6 +142,6 @@ mod test {
             .with_options(Default::default())
             .build(program)
             .source_text;
-        assert_eq!(source, "import {k,Box} from '@kuma-ui/core';export const App=()=>{return <Box as='div' IS_KUMA_DEFAULT={true}><Box as='span' IS_KUMA_DEFAULT={true}>hello</Box></Box>};")
+        assert_eq!(source, "import { k, Box } from \"@kuma-ui/core\";\nexport const App = () => {\n\treturn <Box as=\"div\" IS_KUMA_DEFAULT={true}><Box as=\"span\" IS_KUMA_DEFAULT={true}>hello</Box></Box>;\n};\n")
     }
 }

--- a/packages/wasm/src/transform/visit/replace_k_with_box.rs
+++ b/packages/wasm/src/transform/visit/replace_k_with_box.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
         JSXAttributeValue, JSXElement, JSXElementName, JSXExpression, JSXExpressionContainer,
         JSXIdentifier, JSXMemberExpressionObject, StringLiteral,
     },
-    visit::walk_mut::walk_jsx_element_mut,
+    visit::walk_mut::walk_jsx_element,
     AstBuilder, VisitMut,
 };
 use oxc_span::{Atom, SPAN};
@@ -69,13 +69,11 @@ impl<'a, 'b> VisitMut<'a> for ReplaceKWithBox<'a, 'b> {
                                     value: Some(JSXAttributeValue::ExpressionContainer(
                                         self.ast.alloc(JSXExpressionContainer {
                                             span: SPAN,
-                                            expression: JSXExpression::Expression(
-                                                Expression::BooleanLiteral(self.ast.alloc(
-                                                    BooleanLiteral {
-                                                        span: SPAN,
-                                                        value: true,
-                                                    },
-                                                )),
+                                            expression: JSXExpression::BooleanLiteral(
+                                                self.ast.alloc(BooleanLiteral {
+                                                    span: SPAN,
+                                                    value: true,
+                                                }),
                                             ),
                                         }),
                                     )),
@@ -95,21 +93,21 @@ impl<'a, 'b> VisitMut<'a> for ReplaceKWithBox<'a, 'b> {
                     elem.opening_element.name =
                         JSXElementName::Identifier(self.ast.alloc(JSXIdentifier {
                             span: SPAN,
-                            name: self.ast.new_atom(box_local_name),
+                            name: self.ast.atom(box_local_name),
                         }));
 
                     if let Some(closing_element) = &mut elem.closing_element {
                         closing_element.name =
                             JSXElementName::Identifier(self.ast.alloc(JSXIdentifier {
                                 span: SPAN,
-                                name: self.ast.new_atom(box_local_name),
+                                name: self.ast.atom(box_local_name),
                             }));
                     }
                 }
             }
         }
 
-        walk_jsx_element_mut(self, elem);
+        walk_jsx_element(self, elem);
     }
 }
 
@@ -140,7 +138,8 @@ mod test {
 
         replace_k_with_box.visit_program(program);
 
-        let source = Codegen::<true>::new("", source_text, Default::default())
+        let source = Codegen::new()
+            .with_options(Default::default())
             .build(program)
             .source_text;
         assert_eq!(source, "import {k,Box} from '@kuma-ui/core';export const App=()=>{return <Box as='div' IS_KUMA_DEFAULT={true}><Box as='span' IS_KUMA_DEFAULT={true}>hello</Box></Box>};")

--- a/packages/wasm/src/util/mod.rs
+++ b/packages/wasm/src/util/mod.rs
@@ -1,0 +1,3 @@
+pub fn replace_quotes_and_newlines(source: &str) -> String {
+    source.replace("\"", "'").replace(['\n', '\t'], "")
+}

--- a/packages/wasm/src/util/mod.rs
+++ b/packages/wasm/src/util/mod.rs
@@ -1,3 +1,4 @@
+/// use this function to replace quotes and newlines in the source code for the sake of readability when testing
 pub fn replace_quotes_and_newlines(source: &str) -> String {
     source.replace("\"", "'").replace(['\n', '\t'], "")
 }


### PR DESCRIPTION

close #415 

The previous version of oxc (v0.12.5) rendered non-English characters as escape sequences, so this PR updates oxc (which `@kuma-ui/wasm` depends on to parse JS/TS) to the latest version.