### PR TITLE
Hopefully publish new `next-plugin` version 1.4.1 (1.4.2) including a loose `@types/react` peer dependency

### DIFF
--- a/.changeset/odd-paws-guess.md
+++ b/.changeset/odd-paws-guess.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/next-plugin": patch
+---
+
+Update & publish `next-plugin`.


### PR DESCRIPTION
It seems `@kuma-ui/next-plugin` was not published to npm. It contains a looser `@types/react` peer dependency, fixing this error you get when installing:

```
npm error Could not resolve dependency:
npm error peerOptional @types/react@"^18.0.32" from @kuma-ui/next-plugin@1.4.0
npm error node_modules/@kuma-ui/next-plugin
npm error   @kuma-ui/next-plugin@"^1.4.0" from the root project

npm error Conflicting peer dependency: @types/react@18.3.29
npm error node_modules/@types/react
npm error   peerOptional @types/react@"^18.0.32" from @kuma-ui/next-plugin@1.4.0
npm error   node_modules/@kuma-ui/next-plugin
npm error     @kuma-ui/next-plugin@"^1.4.0" from the root project
```

Original change was done in a443bcaf29cb8088ee94c6d291bb7b9211d70d4b